### PR TITLE
Update boot-sunxi.cmd

### DIFF
--- a/config/bootscripts/boot-sunxi.cmd
+++ b/config/bootscripts/boot-sunxi.cmd
@@ -48,7 +48,7 @@ if test "${docker_optimizations}" = "on"; then setenv bootargs "${bootargs} cgro
 load ${devtype} ${devnum} ${ramdisk_addr_r} ${prefix}uInitrd
 load ${devtype} ${devnum} ${kernel_addr_r} ${prefix}zImage
 
-if test -e ${devtype} ${devnum} "${prefix}.next"; then
+if test -e ${devtype} ${devnum} ${prefix}.next; then
 	echo "Found mainline kernel configuration"
 	load ${devtype} ${devnum} ${fdt_addr_r} ${prefix}dtb/${fdtfile}
 	fdt addr ${fdt_addr_r}


### PR DESCRIPTION
Hi,
I use armbian on Olimexino Lime2-s16M with:
1. System (mainline) installed on SATA-Disk
2. u-boot on SPI
3. without SD-card

When booting the original boot-script with the quotes ("") in line 51 [if test -e ${devtype} ${devnum} "${prefix}.next"; ...]
I see [echo "Found legacy kernel configuration"] in the serial console and the boot scripts stops with error message. The if-statement does not recognise /boot/.next!

After removing the quotes ("") in line 51 the if-statement recognises the file /boot/.next, so i can boot from SATA with u-boot on SPI.
May be this helps.