### PR TITLE
Patches ported from LibreElec for better media support

### DIFF
--- a/config/kernel/linux-sunxi-olinuxino.config
+++ b/config/kernel/linux-sunxi-olinuxino.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.2.4 Kernel Configuration
+# Linux/arm 5.2.21 Kernel Configuration
 #
 
 #
@@ -458,7 +458,6 @@ CONFIG_SECCOMP=y
 # CONFIG_PARAVIRT is not set
 # CONFIG_PARAVIRT_TIME_ACCOUNTING is not set
 # CONFIG_XEN is not set
-CONFIG_STACKPROTECTOR_PER_TASK=y
 # end of Kernel Features
 
 #
@@ -669,18 +668,8 @@ CONFIG_REFCOUNT_FULL=y
 CONFIG_ARCH_HAS_GCOV_PROFILE_ALL=y
 # end of GCOV-based kernel profiling
 
-CONFIG_PLUGIN_HOSTCC="g++"
+CONFIG_PLUGIN_HOSTCC=""
 CONFIG_HAVE_GCC_PLUGINS=y
-CONFIG_GCC_PLUGINS=y
-
-#
-# GCC plugins
-#
-# CONFIG_GCC_PLUGIN_CYC_COMPLEXITY is not set
-# CONFIG_GCC_PLUGIN_LATENT_ENTROPY is not set
-# CONFIG_GCC_PLUGIN_RANDSTRUCT is not set
-CONFIG_GCC_PLUGIN_ARM_SSP_PER_TASK=y
-# end of GCC plugins
 # end of General architecture-dependent options
 
 CONFIG_RT_MUTEXES=y
@@ -2525,6 +2514,9 @@ CONFIG_WLAN_VENDOR_TI=y
 # CONFIG_WL12XX is not set
 # CONFIG_WL18XX is not set
 # CONFIG_WLCORE is not set
+CONFIG_RTL8822BU=m
+CONFIG_RTL8188EU=m
+CONFIG_RTL8812AU=m
 CONFIG_WLAN_VENDOR_ZYDAS=y
 # CONFIG_USB_ZD1201 is not set
 # CONFIG_ZD1211RW is not set
@@ -3576,7 +3568,7 @@ CONFIG_MEDIA_SDR_SUPPORT=y
 # CONFIG_CEC_PIN_ERROR_INJ is not set
 CONFIG_MEDIA_CONTROLLER=y
 CONFIG_MEDIA_CONTROLLER_DVB=y
-# CONFIG_MEDIA_CONTROLLER_REQUEST_API is not set
+CONFIG_MEDIA_CONTROLLER_REQUEST_API=y
 CONFIG_VIDEO_DEV=y
 CONFIG_VIDEO_V4L2_SUBDEV_API=y
 CONFIG_VIDEO_V4L2=y
@@ -5485,6 +5477,7 @@ CONFIG_AD9834=m
 CONFIG_STAGING_MEDIA=y
 CONFIG_I2C_BCM2048=m
 CONFIG_VIDEO_SUNXI=y
+CONFIG_VIDEO_SUNXI_CEDRUS=m
 
 #
 # soc_camera sensor drivers
@@ -6612,9 +6605,6 @@ CONFIG_LSM="yama,loadpin,safesetid,integrity"
 # Memory initialization
 #
 CONFIG_INIT_STACK_NONE=y
-# CONFIG_GCC_PLUGIN_STRUCTLEAK_USER is not set
-# CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF is not set
-# CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF_ALL is not set
 # end of Memory initialization
 # end of Kernel hardening options
 # end of Security options

--- a/patch/kernel/sunxi-next-olinuxino/0151-backport-from-5.3.patch
+++ b/patch/kernel/sunxi-next-olinuxino/0151-backport-from-5.3.patch
@@ -1,0 +1,2252 @@
+From aaf6d07a90c425c92f77b9e1ffd2f9b65421e4ec Mon Sep 17 00:00:00 2001
+From: hehopmajieh <hehopmajieh@debian.bg>
+Date: Fri, 3 Jan 2020 23:20:04 +0200
+Subject: [PATCH 1/7] Bacport from linux-5.3 based on LibreElec patch series
+
+---
+ Documentation/media/uapi/v4l/biblio.rst       |   9 +
+ .../media/uapi/v4l/ext-ctrls-codec.rst        | 625 ++++++++++++++++++
+ .../media/uapi/v4l/pixfmt-compressed.rst      |  25 +
+ .../media/uapi/v4l/vidioc-queryctrl.rst       |  30 +
+ .../media/videodev2.h.rst.exceptions          |   5 +
+ arch/arm/boot/dts/sun8i-h3-beelink-x2.dts     |   4 +
+ .../dts/allwinner/sun50i-a64-orangepi-win.dts |  23 +
+ drivers/media/v4l2-core/v4l2-ctrls.c          |  65 ++
+ drivers/media/v4l2-core/v4l2-ioctl.c          |   1 +
+ drivers/staging/media/sunxi/cedrus/Makefile   |   3 +-
+ drivers/staging/media/sunxi/cedrus/cedrus.c   |  42 +-
+ drivers/staging/media/sunxi/cedrus/cedrus.h   |  39 +-
+ .../staging/media/sunxi/cedrus/cedrus_dec.c   |  13 +
+ .../staging/media/sunxi/cedrus/cedrus_h264.c  | 576 ++++++++++++++++
+ .../staging/media/sunxi/cedrus/cedrus_hw.c    |   6 +-
+ .../staging/media/sunxi/cedrus/cedrus_hw.h    |   2 -
+ .../staging/media/sunxi/cedrus/cedrus_regs.h  |  91 +++
+ .../staging/media/sunxi/cedrus/cedrus_video.c |   9 +
+ include/media/h264-ctrls.h                    | 197 ++++++
+ include/media/v4l2-ctrls.h                    |  13 +-
+ include/uapi/linux/v4l2-controls.h            |  18 +
+ 21 files changed, 1787 insertions(+), 9 deletions(-)
+ create mode 100644 drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+ create mode 100644 include/media/h264-ctrls.h
+
+diff --git a/Documentation/media/uapi/v4l/biblio.rst b/Documentation/media/uapi/v4l/biblio.rst
+index ec33768c0..8f4eb8823 100644
+--- a/Documentation/media/uapi/v4l/biblio.rst
++++ b/Documentation/media/uapi/v4l/biblio.rst
+@@ -122,6 +122,15 @@ ITU BT.1119
+ 
+ :author:    International Telecommunication Union (http://www.itu.ch)
+ 
++.. _h264:
++
++ITU-T Rec. H.264 Specification (04/2017 Edition)
++================================================
++
++:title:     ITU-T Recommendation H.264 "Advanced Video Coding for Generic Audiovisual Services"
++
++:author:    International Telecommunication Union (http://www.itu.ch)
++
+ .. _jfif:
+ 
+ JFIF
+diff --git a/Documentation/media/uapi/v4l/ext-ctrls-codec.rst b/Documentation/media/uapi/v4l/ext-ctrls-codec.rst
+index 4a8446203..b0c178f0f 100644
+--- a/Documentation/media/uapi/v4l/ext-ctrls-codec.rst
++++ b/Documentation/media/uapi/v4l/ext-ctrls-codec.rst
+@@ -759,6 +759,32 @@ enum v4l2_mpeg_video_h264_level -
+ 
+ 
+ 
++.. _v4l2-mpeg-video-mpeg2-level:
++
++``V4L2_CID_MPEG_VIDEO_MPEG2_LEVEL``
++    (enum)
++
++enum v4l2_mpeg_video_mpeg2_level -
++    The level information for the MPEG2 elementary stream. Applicable to
++    MPEG2 codecs. Possible values are:
++
++
++
++.. flat-table::
++    :header-rows:  0
++    :stub-columns: 0
++
++    * - ``V4L2_MPEG_VIDEO_MPEG2_LEVEL_LOW``
++      - Low Level (LL)
++    * - ``V4L2_MPEG_VIDEO_MPEG2_LEVEL_MAIN``
++      - Main Level (ML)
++    * - ``V4L2_MPEG_VIDEO_MPEG2_LEVEL_HIGH_1440``
++      - High-1440 Level (H-14)
++    * - ``V4L2_MPEG_VIDEO_MPEG2_LEVEL_HIGH``
++      - High Level (HL)
++
++
++
+ .. _v4l2-mpeg-video-mpeg4-level:
+ 
+ ``V4L2_CID_MPEG_VIDEO_MPEG4_LEVEL``
+@@ -845,6 +871,36 @@ enum v4l2_mpeg_video_h264_profile -
+ 
+ 
+ 
++.. _v4l2-mpeg-video-mpeg2-profile:
++
++``V4L2_CID_MPEG_VIDEO_MPEG2_PROFILE``
++    (enum)
++
++enum v4l2_mpeg_video_mpeg2_profile -
++    The profile information for MPEG2. Applicable to MPEG2 codecs.
++    Possible values are:
++
++
++
++.. flat-table::
++    :header-rows:  0
++    :stub-columns: 0
++
++    * - ``V4L2_MPEG_VIDEO_MPEG2_PROFILE_SIMPLE``
++      - Simple profile (SP)
++    * - ``V4L2_MPEG_VIDEO_MPEG2_PROFILE_MAIN``
++      - Main profile (MP)
++    * - ``V4L2_MPEG_VIDEO_MPEG2_PROFILE_SNR_SCALABLE``
++      - SNR Scalable profile (SNR)
++    * - ``V4L2_MPEG_VIDEO_MPEG2_PROFILE_SPATIALLY_SCALABLE``
++      - Spatially Scalable profile (Spt)
++    * - ``V4L2_MPEG_VIDEO_MPEG2_PROFILE_HIGH``
++      - High profile (HP)
++    * - ``V4L2_MPEG_VIDEO_MPEG2_PROFILE_MULTIVIEW``
++      - Multi-view profile (MVP)
++
++
++
+ .. _v4l2-mpeg-video-mpeg4-profile:
+ 
+ ``V4L2_CID_MPEG_VIDEO_MPEG4_PROFILE``
+@@ -1395,6 +1451,575 @@ enum v4l2_mpeg_video_h264_hierarchical_coding_type -
+       - Layer number
+ 
+ 
++.. _v4l2-mpeg-h264:
++
++``V4L2_CID_MPEG_VIDEO_H264_SPS (struct)``
++    Specifies the sequence parameter set (as extracted from the
++    bitstream) for the associated H264 slice data. This includes the
++    necessary parameters for configuring a stateless hardware decoding
++    pipeline for H264. The bitstream parameters are defined according
++    to :ref:`h264`, section 7.4.2.1.1 "Sequence Parameter Set Data
++    Semantics". For further documentation, refer to the above
++    specification, unless there is an explicit comment stating
++    otherwise.
++
++    .. note::
++
++       This compound control is not yet part of the public kernel API and
++       it is expected to change.
++
++.. c:type:: v4l2_ctrl_h264_sps
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_ctrl_h264_sps
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u8
++      - ``profile_idc``
++      -
++    * - __u8
++      - ``constraint_set_flags``
++      - See :ref:`Sequence Parameter Set Constraints Set Flags <h264_sps_constraints_set_flags>`
++    * - __u8
++      - ``level_idc``
++      -
++    * - __u8
++      - ``seq_parameter_set_id``
++      -
++    * - __u8
++      - ``chroma_format_idc``
++      -
++    * - __u8
++      - ``bit_depth_luma_minus8``
++      -
++    * - __u8
++      - ``bit_depth_chroma_minus8``
++      -
++    * - __u8
++      - ``log2_max_frame_num_minus4``
++      -
++    * - __u8
++      - ``pic_order_cnt_type``
++      -
++    * - __u8
++      - ``log2_max_pic_order_cnt_lsb_minus4``
++      -
++    * - __u8
++      - ``max_num_ref_frames``
++      -
++    * - __u8
++      - ``num_ref_frames_in_pic_order_cnt_cycle``
++      -
++    * - __s32
++      - ``offset_for_ref_frame[255]``
++      -
++    * - __s32
++      - ``offset_for_non_ref_pic``
++      -
++    * - __s32
++      - ``offset_for_top_to_bottom_field``
++      -
++    * - __u16
++      - ``pic_width_in_mbs_minus1``
++      -
++    * - __u16
++      - ``pic_height_in_map_units_minus1``
++      -
++    * - __u32
++      - ``flags``
++      - See :ref:`Sequence Parameter Set Flags <h264_sps_flags>`
++
++.. _h264_sps_constraints_set_flags:
++
++``Sequence Parameter Set Constraints Set Flags``
++
++.. cssclass:: longtable
++
++.. flat-table::
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - ``V4L2_H264_SPS_CONSTRAINT_SET0_FLAG``
++      - 0x00000001
++      -
++    * - ``V4L2_H264_SPS_CONSTRAINT_SET1_FLAG``
++      - 0x00000002
++      -
++    * - ``V4L2_H264_SPS_CONSTRAINT_SET2_FLAG``
++      - 0x00000004
++      -
++    * - ``V4L2_H264_SPS_CONSTRAINT_SET3_FLAG``
++      - 0x00000008
++      -
++    * - ``V4L2_H264_SPS_CONSTRAINT_SET4_FLAG``
++      - 0x00000010
++      -
++    * - ``V4L2_H264_SPS_CONSTRAINT_SET5_FLAG``
++      - 0x00000020
++      -
++
++.. _h264_sps_flags:
++
++``Sequence Parameter Set Flags``
++
++.. cssclass:: longtable
++
++.. flat-table::
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - ``V4L2_H264_SPS_FLAG_SEPARATE_COLOUR_PLANE``
++      - 0x00000001
++      -
++    * - ``V4L2_H264_SPS_FLAG_QPPRIME_Y_ZERO_TRANSFORM_BYPASS``
++      - 0x00000002
++      -
++    * - ``V4L2_H264_SPS_FLAG_DELTA_PIC_ORDER_ALWAYS_ZERO``
++      - 0x00000004
++      -
++    * - ``V4L2_H264_SPS_FLAG_GAPS_IN_FRAME_NUM_VALUE_ALLOWED``
++      - 0x00000008
++      -
++    * - ``V4L2_H264_SPS_FLAG_FRAME_MBS_ONLY``
++      - 0x00000010
++      -
++    * - ``V4L2_H264_SPS_FLAG_MB_ADAPTIVE_FRAME_FIELD``
++      - 0x00000020
++      -
++    * - ``V4L2_H264_SPS_FLAG_DIRECT_8X8_INFERENCE``
++      - 0x00000040
++      -
++
++``V4L2_CID_MPEG_VIDEO_H264_PPS (struct)``
++    Specifies the picture parameter set (as extracted from the
++    bitstream) for the associated H264 slice data. This includes the
++    necessary parameters for configuring a stateless hardware decoding
++    pipeline for H264.  The bitstream parameters are defined according
++    to :ref:`h264`, section 7.4.2.2 "Picture Parameter Set RBSP
++    Semantics". For further documentation, refer to the above
++    specification, unless there is an explicit comment stating
++    otherwise.
++
++    .. note::
++
++       This compound control is not yet part of the public kernel API and
++       it is expected to change.
++
++.. c:type:: v4l2_ctrl_h264_pps
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_ctrl_h264_pps
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u8
++      - ``pic_parameter_set_id``
++      -
++    * - __u8
++      - ``seq_parameter_set_id``
++      -
++    * - __u8
++      - ``num_slice_groups_minus1``
++      -
++    * - __u8
++      - ``num_ref_idx_l0_default_active_minus1``
++      -
++    * - __u8
++      - ``num_ref_idx_l1_default_active_minus1``
++      -
++    * - __u8
++      - ``weighted_bipred_idc``
++      -
++    * - __s8
++      - ``pic_init_qp_minus26``
++      -
++    * - __s8
++      - ``pic_init_qs_minus26``
++      -
++    * - __s8
++      - ``chroma_qp_index_offset``
++      -
++    * - __s8
++      - ``second_chroma_qp_index_offset``
++      -
++    * - __u16
++      - ``flags``
++      - See :ref:`Picture Parameter Set Flags <h264_pps_flags>`
++
++.. _h264_pps_flags:
++
++``Picture Parameter Set Flags``
++
++.. cssclass:: longtable
++
++.. flat-table::
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - ``V4L2_H264_PPS_FLAG_ENTROPY_CODING_MODE``
++      - 0x00000001
++      -
++    * - ``V4L2_H264_PPS_FLAG_BOTTOM_FIELD_PIC_ORDER_IN_FRAME_PRESENT``
++      - 0x00000002
++      -
++    * - ``V4L2_H264_PPS_FLAG_WEIGHTED_PRED``
++      - 0x00000004
++      -
++    * - ``V4L2_H264_PPS_FLAG_DEBLOCKING_FILTER_CONTROL_PRESENT``
++      - 0x00000008
++      -
++    * - ``V4L2_H264_PPS_FLAG_CONSTRAINED_INTRA_PRED``
++      - 0x00000010
++      -
++    * - ``V4L2_H264_PPS_FLAG_REDUNDANT_PIC_CNT_PRESENT``
++      - 0x00000020
++      -
++    * - ``V4L2_H264_PPS_FLAG_TRANSFORM_8X8_MODE``
++      - 0x00000040
++      -
++    * - ``V4L2_H264_PPS_FLAG_PIC_SCALING_MATRIX_PRESENT``
++      - 0x00000080
++      -
++
++``V4L2_CID_MPEG_VIDEO_H264_SCALING_MATRIX (struct)``
++    Specifies the scaling matrix (as extracted from the bitstream) for
++    the associated H264 slice data. The bitstream parameters are
++    defined according to :ref:`h264`, section 7.4.2.1.1.1 "Scaling
++    List Semantics".For further documentation, refer to the above
++    specification, unless there is an explicit comment stating
++    otherwise.
++
++    .. note::
++
++       This compound control is not yet part of the public kernel API and
++       it is expected to change.
++
++.. c:type:: v4l2_ctrl_h264_scaling_matrix
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_ctrl_h264_scaling_matrix
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u8
++      - ``scaling_list_4x4[6][16]``
++      -
++    * - __u8
++      - ``scaling_list_8x8[6][64]``
++      -
++
++``V4L2_CID_MPEG_VIDEO_H264_SLICE_PARAMS (struct)``
++    Specifies the slice parameters (as extracted from the bitstream)
++    for the associated H264 slice data. This includes the necessary
++    parameters for configuring a stateless hardware decoding pipeline
++    for H264.  The bitstream parameters are defined according to
++    :ref:`h264`, section 7.4.3 "Slice Header Semantics". For further
++    documentation, refer to the above specification, unless there is
++    an explicit comment stating otherwise.
++
++    .. note::
++
++       This compound control is not yet part of the public kernel API
++       and it is expected to change.
++
++       This structure is expected to be passed as an array, with one
++       entry for each slice included in the bitstream buffer.
++
++.. c:type:: v4l2_ctrl_h264_slice_params
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_ctrl_h264_slice_params
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u32
++      - ``size``
++      -
++    * - __u32
++      - ``header_bit_size``
++      -
++    * - __u16
++      - ``first_mb_in_slice``
++      -
++    * - __u8
++      - ``slice_type``
++      -
++    * - __u8
++      - ``pic_parameter_set_id``
++      -
++    * - __u8
++      - ``colour_plane_id``
++      -
++    * - __u8
++      - ``redundant_pic_cnt``
++      -
++    * - __u16
++      - ``frame_num``
++      -
++    * - __u16
++      - ``idr_pic_id``
++      -
++    * - __u16
++      - ``pic_order_cnt_lsb``
++      -
++    * - __s32
++      - ``delta_pic_order_cnt_bottom``
++      -
++    * - __s32
++      - ``delta_pic_order_cnt0``
++      -
++    * - __s32
++      - ``delta_pic_order_cnt1``
++      -
++    * - struct :c:type:`v4l2_h264_pred_weight_table`
++      - ``pred_weight_table``
++      -
++    * - __u32
++      - ``dec_ref_pic_marking_bit_size``
++      -
++    * - __u32
++      - ``pic_order_cnt_bit_size``
++      -
++    * - __u8
++      - ``cabac_init_idc``
++      -
++    * - __s8
++      - ``slice_qp_delta``
++      -
++    * - __s8
++      - ``slice_qs_delta``
++      -
++    * - __u8
++      - ``disable_deblocking_filter_idc``
++      -
++    * - __s8
++      - ``slice_alpha_c0_offset_div2``
++      -
++    * - __s8
++      - ``slice_beta_offset_div2``
++      -
++    * - __u8
++      - ``num_ref_idx_l0_active_minus1``
++      -
++    * - __u8
++      - ``num_ref_idx_l1_active_minus1``
++      -
++    * - __u32
++      - ``slice_group_change_cycle``
++      -
++    * - __u8
++      - ``ref_pic_list0[32]``
++      - Reference picture list after applying the per-slice modifications
++    * - __u8
++      - ``ref_pic_list1[32]``
++      - Reference picture list after applying the per-slice modifications
++    * - __u32
++      - ``flags``
++      - See :ref:`Slice Parameter Flags <h264_slice_flags>`
++
++.. _h264_slice_flags:
++
++``Slice Parameter Set Flags``
++
++.. cssclass:: longtable
++
++.. flat-table::
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - ``V4L2_H264_SLICE_FLAG_FIELD_PIC``
++      - 0x00000001
++      -
++    * - ``V4L2_H264_SLICE_FLAG_BOTTOM_FIELD``
++      - 0x00000002
++      -
++    * - ``V4L2_H264_SLICE_FLAG_DIRECT_SPATIAL_MV_PRED``
++      - 0x00000004
++      -
++    * - ``V4L2_H264_SLICE_FLAG_SP_FOR_SWITCH``
++      - 0x00000008
++      -
++
++``Prediction Weight Table``
++
++    The bitstream parameters are defined according to :ref:`h264`,
++    section 7.4.3.2 "Prediction Weight Table Semantics". For further
++    documentation, refer to the above specification, unless there is
++    an explicit comment stating otherwise.
++
++.. c:type:: v4l2_h264_pred_weight_table
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_h264_pred_weight_table
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u16
++      - ``luma_log2_weight_denom``
++      -
++    * - __u16
++      - ``chroma_log2_weight_denom``
++      -
++    * - struct :c:type:`v4l2_h264_weight_factors`
++      - ``weight_factors[2]``
++      - The weight factors at index 0 are the weight factors for the reference
++        list 0, the one at index 1 for the reference list 1.
++
++.. c:type:: v4l2_h264_weight_factors
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_h264_weight_factors
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __s16
++      - ``luma_weight[32]``
++      -
++    * - __s16
++      - ``luma_offset[32]``
++      -
++    * - __s16
++      - ``chroma_weight[32][2]``
++      -
++    * - __s16
++      - ``chroma_offset[32][2]``
++      -
++
++``V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS (struct)``
++    Specifies the decode parameters (as extracted from the bitstream)
++    for the associated H264 slice data. This includes the necessary
++    parameters for configuring a stateless hardware decoding pipeline
++    for H264. The bitstream parameters are defined according to
++    :ref:`h264`. For further documentation, refer to the above
++    specification, unless there is an explicit comment stating
++    otherwise.
++
++    .. note::
++
++       This compound control is not yet part of the public kernel API and
++       it is expected to change.
++
++.. c:type:: v4l2_ctrl_h264_decode_params
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_ctrl_h264_decode_params
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u32
++      - ``num_slices``
++      - Number of slices needed to decode the current frame
++    * - __u32
++      - ``nal_ref_idc``
++      - NAL reference ID value coming from the NAL Unit header
++    * - __u8
++      - ``ref_pic_list_p0[32]``
++      - Backward reference list used by P-frames in the original bitstream order
++    * - __u8
++      - ``ref_pic_list_b0[32]``
++      - Backward reference list used by B-frames in the original bitstream order
++    * - __u8
++      - ``ref_pic_list_b1[32]``
++      - Forward reference list used by B-frames in the original bitstream order
++    * - __s32
++      - ``top_field_order_cnt``
++      - Picture Order Count for the coded top field
++    * - __s32
++      - ``bottom_field_order_cnt``
++      - Picture Order Count for the coded bottom field
++    * - __u32
++      - ``flags``
++      - See :ref:`Decode Parameters Flags <h264_decode_params_flags>`
++    * - struct :c:type:`v4l2_h264_dpb_entry`
++      - ``dpb[16]``
++      -
++
++.. _h264_decode_params_flags:
++
++``Decode Parameters Flags``
++
++.. cssclass:: longtable
++
++.. flat-table::
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - ``V4L2_H264_DECODE_PARAM_FLAG_IDR_PIC``
++      - 0x00000001
++      - That picture is an IDR picture
++
++.. c:type:: v4l2_h264_dpb_entry
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_h264_dpb_entry
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u64
++      - ``reference_ts``
++      - Timestamp of the V4L2 capture buffer to use as reference, used
++        with B-coded and P-coded frames. The timestamp refers to the
++	``timestamp`` field in struct :c:type:`v4l2_buffer`. Use the
++	:c:func:`v4l2_timeval_to_ns()` function to convert the struct
++	:c:type:`timeval` in struct :c:type:`v4l2_buffer` to a __u64.
++    * - __u16
++      - ``frame_num``
++      -
++    * - __u16
++      - ``pic_num``
++      -
++    * - __s32
++      - ``top_field_order_cnt``
++      -
++    * - __s32
++      - ``bottom_field_order_cnt``
++      -
++    * - __u32
++      - ``flags``
++      - See :ref:`DPB Entry Flags <h264_dpb_flags>`
++
++.. _h264_dpb_flags:
++
++``DPB Entries Flags``
++
++.. cssclass:: longtable
++
++.. flat-table::
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - ``V4L2_H264_DPB_ENTRY_FLAG_VALID``
++      - 0x00000001
++      - The DPB entry is valid and should be considered
++    * - ``V4L2_H264_DPB_ENTRY_FLAG_ACTIVE``
++      - 0x00000002
++      - The DPB entry is currently being used as a reference frame
++    * - ``V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM``
++      - 0x00000004
++      - The DPB entry is a long term reference frame
+ 
+ .. _v4l2-mpeg-mpeg2:
+ 
+diff --git a/Documentation/media/uapi/v4l/pixfmt-compressed.rst b/Documentation/media/uapi/v4l/pixfmt-compressed.rst
+index 6c961cfb7..4b701fc76 100644
+--- a/Documentation/media/uapi/v4l/pixfmt-compressed.rst
++++ b/Documentation/media/uapi/v4l/pixfmt-compressed.rst
+@@ -52,6 +52,31 @@ Compressed Formats
+       - ``V4L2_PIX_FMT_H264_MVC``
+       - 'M264'
+       - H264 MVC video elementary stream.
++    * .. _V4L2-PIX-FMT-H264-SLICE-RAW:
++
++      - ``V4L2_PIX_FMT_H264_SLICE_RAW``
++      - 'S264'
++      - H264 parsed slice data, without the start code and as
++	extracted from the H264 bitstream.  This format is adapted for
++	stateless video decoders that implement an H264 pipeline
++	(using the :ref:`mem2mem` and :ref:`media-request-api`).
++	Metadata associated with the frame to decode are required to
++	be passed through the ``V4L2_CID_MPEG_VIDEO_H264_SPS``,
++	``V4L2_CID_MPEG_VIDEO_H264_PPS``,
++	``V4L2_CID_MPEG_VIDEO_H264_SCALING_MATRIX``,
++	``V4L2_CID_MPEG_VIDEO_H264_SLICE_PARAMS`` and
++	``V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS`` controls.  See the
++	:ref:`associated Codec Control IDs <v4l2-mpeg-h264>`.  Exactly
++	one output and one capture buffer must be provided for use
++	with this pixel format. The output buffer must contain the
++	appropriate number of macroblocks to decode a full
++	corresponding frame to the matching capture buffer.
++
++	.. note::
++
++	   This format is not yet part of the public kernel API and it
++	   is expected to change.
++
+     * .. _V4L2-PIX-FMT-H263:
+ 
+       - ``V4L2_PIX_FMT_H263``
+diff --git a/Documentation/media/uapi/v4l/vidioc-queryctrl.rst b/Documentation/media/uapi/v4l/vidioc-queryctrl.rst
+index f824162d0..dc5006320 100644
+--- a/Documentation/media/uapi/v4l/vidioc-queryctrl.rst
++++ b/Documentation/media/uapi/v4l/vidioc-queryctrl.rst
+@@ -443,6 +443,36 @@ See also the examples in :ref:`control`.
+       - n/a
+       - A struct :c:type:`v4l2_ctrl_mpeg2_quantization`, containing MPEG-2
+ 	quantization matrices for stateless video decoders.
++    * - ``V4L2_CTRL_TYPE_H264_SPS``
++      - n/a
++      - n/a
++      - n/a
++      - A struct :c:type:`v4l2_ctrl_h264_sps`, containing H264
++	sequence parameters for stateless video decoders.
++    * - ``V4L2_CTRL_TYPE_H264_PPS``
++      - n/a
++      - n/a
++      - n/a
++      - A struct :c:type:`v4l2_ctrl_h264_pps`, containing H264
++	picture parameters for stateless video decoders.
++    * - ``V4L2_CTRL_TYPE_H264_SCALING_MATRIX``
++      - n/a
++      - n/a
++      - n/a
++      - A struct :c:type:`v4l2_ctrl_h264_scaling_matrix`, containing H264
++	scaling matrices for stateless video decoders.
++    * - ``V4L2_CTRL_TYPE_H264_SLICE_PARAMS``
++      - n/a
++      - n/a
++      - n/a
++      - A struct :c:type:`v4l2_ctrl_h264_slice_params`, containing H264
++	slice parameters for stateless video decoders.
++    * - ``V4L2_CTRL_TYPE_H264_DECODE_PARAMS``
++      - n/a
++      - n/a
++      - n/a
++      - A struct :c:type:`v4l2_ctrl_h264_decode_params`, containing H264
++	decode parameters for stateless video decoders.
+ 
+ .. tabularcolumns:: |p{6.6cm}|p{2.2cm}|p{8.7cm}|
+ 
+diff --git a/Documentation/media/videodev2.h.rst.exceptions b/Documentation/media/videodev2.h.rst.exceptions
+index 64d348e67..55cbe324b 100644
+--- a/Documentation/media/videodev2.h.rst.exceptions
++++ b/Documentation/media/videodev2.h.rst.exceptions
+@@ -136,6 +136,11 @@ replace symbol V4L2_CTRL_TYPE_U32 :c:type:`v4l2_ctrl_type`
+ replace symbol V4L2_CTRL_TYPE_U8 :c:type:`v4l2_ctrl_type`
+ replace symbol V4L2_CTRL_TYPE_MPEG2_SLICE_PARAMS :c:type:`v4l2_ctrl_type`
+ replace symbol V4L2_CTRL_TYPE_MPEG2_QUANTIZATION :c:type:`v4l2_ctrl_type`
++replace symbol V4L2_CTRL_TYPE_H264_SPS :c:type:`v4l2_ctrl_type`
++replace symbol V4L2_CTRL_TYPE_H264_PPS :c:type:`v4l2_ctrl_type`
++replace symbol V4L2_CTRL_TYPE_H264_SCALING_MATRIX :c:type:`v4l2_ctrl_type`
++replace symbol V4L2_CTRL_TYPE_H264_SLICE_PARAMS :c:type:`v4l2_ctrl_type`
++replace symbol V4L2_CTRL_TYPE_H264_DECODE_PARAMS :c:type:`v4l2_ctrl_type`
+ 
+ # V4L2 capability defines
+ replace define V4L2_CAP_VIDEO_CAPTURE device-capabilities
+diff --git a/arch/arm/boot/dts/sun8i-h3-beelink-x2.dts b/arch/arm/boot/dts/sun8i-h3-beelink-x2.dts
+index 6277f13f3..ac9e26b1d 100644
+--- a/arch/arm/boot/dts/sun8i-h3-beelink-x2.dts
++++ b/arch/arm/boot/dts/sun8i-h3-beelink-x2.dts
+@@ -90,6 +90,8 @@
+ 	wifi_pwrseq: wifi_pwrseq {
+ 		compatible = "mmc-pwrseq-simple";
+ 		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
++		clocks = <&rtc 1>;
++		clock-names = "ext_clock";
+ 	};
+ 
+ 	sound_spdif {
+@@ -155,6 +157,8 @@
+ 
+ &mmc1 {
+ 	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
+ 	bus-width = <4>;
+ 	non-removable;
+ 	status = "okay";
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-orangepi-win.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-orangepi-win.dts
+index 510f66122..5ef3c62c7 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-a64-orangepi-win.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-orangepi-win.dts
+@@ -109,6 +109,8 @@
+ 	wifi_pwrseq: wifi_pwrseq {
+ 		compatible = "mmc-pwrseq-simple";
+ 		reset-gpios = <&r_pio 0 8 GPIO_ACTIVE_LOW>; /* PL8 */
++		clocks = <&rtc 1>;
++		clock-names = "ext_clock";
+ 	};
+ };
+ 
+@@ -170,6 +172,14 @@
+ 	bus-width = <4>;
+ 	non-removable;
+ 	status = "okay";
++
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++		interrupt-parent = <&r_pio>;
++		interrupts = <0 7 IRQ_TYPE_LEVEL_LOW>; /* PL7 */
++		interrupt-names = "host-wake";
++	};
+ };
+ 
+ &ohci0 {
+@@ -342,7 +352,20 @@
+ &uart1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	uart-has-rtscts;
+ 	status = "okay";
++
++	bluetooth {
++		compatible = "brcm,bcm43438-bt";
++		max-speed = <1500000>;
++		clocks = <&rtc 1>;
++		clock-names = "lpo";
++		vbat-supply = <&reg_dldo2>;
++		vddio-supply = <&reg_dldo4>;
++		device-wakeup-gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; /* PL6 */
++		host-wakeup-gpios = <&r_pio 0 5 GPIO_ACTIVE_HIGH>; /* PL5 */
++		shutdown-gpios = <&r_pio 0 4 GPIO_ACTIVE_HIGH>; /* PL4 */
++	};
+ };
+ 
+ /* On Pi-2 connector, RTS/CTS optional */
+diff --git a/drivers/media/v4l2-core/v4l2-ctrls.c b/drivers/media/v4l2-core/v4l2-ctrls.c
+index 4d385489b..e25a528f4 100644
+--- a/drivers/media/v4l2-core/v4l2-ctrls.c
++++ b/drivers/media/v4l2-core/v4l2-ctrls.c
+@@ -394,6 +394,21 @@ const char * const *v4l2_ctrl_get_menu(u32 id)
+ 		"Explicit",
+ 		NULL,
+ 	};
++	static const char * const mpeg_mpeg2_level[] = {
++		"Low",
++		"Main",
++		"High 1440",
++		"High",
++		NULL,
++	};
++	static const char * const mpeg2_profile[] = {
++		"Simple",
++		"Main",
++		"SNR Scalable",
++		"Spatially Scalable",
++		"High",
++		NULL,
++	};
+ 	static const char * const mpeg_mpeg4_level[] = {
+ 		"0",
+ 		"0b",
+@@ -610,6 +625,10 @@ const char * const *v4l2_ctrl_get_menu(u32 id)
+ 		return h264_fp_arrangement_type;
+ 	case V4L2_CID_MPEG_VIDEO_H264_FMO_MAP_TYPE:
+ 		return h264_fmo_map_type;
++	case V4L2_CID_MPEG_VIDEO_MPEG2_LEVEL:
++		return mpeg_mpeg2_level;
++	case V4L2_CID_MPEG_VIDEO_MPEG2_PROFILE:
++		return mpeg2_profile;
+ 	case V4L2_CID_MPEG_VIDEO_MPEG4_LEVEL:
+ 		return mpeg_mpeg4_level;
+ 	case V4L2_CID_MPEG_VIDEO_MPEG4_PROFILE:
+@@ -820,6 +839,13 @@ const char *v4l2_ctrl_get_name(u32 id)
+ 	case V4L2_CID_MPEG_VIDEO_H264_I_FRAME_MAX_QP:		return "H264 I-Frame Maximum QP Value";
+ 	case V4L2_CID_MPEG_VIDEO_H264_P_FRAME_MIN_QP:		return "H264 P-Frame Minimum QP Value";
+ 	case V4L2_CID_MPEG_VIDEO_H264_P_FRAME_MAX_QP:		return "H264 P-Frame Maximum QP Value";
++	case V4L2_CID_MPEG_VIDEO_H264_SPS:			return "H264 Sequence Parameter Set";
++	case V4L2_CID_MPEG_VIDEO_H264_PPS:			return "H264 Picture Parameter Set";
++	case V4L2_CID_MPEG_VIDEO_H264_SCALING_MATRIX:		return "H264 Scaling Matrix";
++	case V4L2_CID_MPEG_VIDEO_H264_SLICE_PARAMS:		return "H264 Slice Parameters";
++	case V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS:		return "H264 Decode Parameters";
++	case V4L2_CID_MPEG_VIDEO_MPEG2_LEVEL:			return "MPEG2 Level";
++	case V4L2_CID_MPEG_VIDEO_MPEG2_PROFILE:			return "MPEG2 Profile";
+ 	case V4L2_CID_MPEG_VIDEO_MPEG4_I_FRAME_QP:		return "MPEG4 I-Frame QP Value";
+ 	case V4L2_CID_MPEG_VIDEO_MPEG4_P_FRAME_QP:		return "MPEG4 P-Frame QP Value";
+ 	case V4L2_CID_MPEG_VIDEO_MPEG4_B_FRAME_QP:		return "MPEG4 B-Frame QP Value";
+@@ -1184,6 +1210,8 @@ void v4l2_ctrl_fill(u32 id, const char **name, enum v4l2_ctrl_type *type,
+ 	case V4L2_CID_MPEG_VIDEO_H264_VUI_SAR_IDC:
+ 	case V4L2_CID_MPEG_VIDEO_H264_SEI_FP_ARRANGEMENT_TYPE:
+ 	case V4L2_CID_MPEG_VIDEO_H264_FMO_MAP_TYPE:
++	case V4L2_CID_MPEG_VIDEO_MPEG2_LEVEL:
++	case V4L2_CID_MPEG_VIDEO_MPEG2_PROFILE:
+ 	case V4L2_CID_MPEG_VIDEO_MPEG4_LEVEL:
+ 	case V4L2_CID_MPEG_VIDEO_MPEG4_PROFILE:
+ 	case V4L2_CID_JPEG_CHROMA_SUBSAMPLING:
+@@ -1301,6 +1329,21 @@ void v4l2_ctrl_fill(u32 id, const char **name, enum v4l2_ctrl_type *type,
+ 	case V4L2_CID_MPEG_VIDEO_FWHT_PARAMS:
+ 		*type = V4L2_CTRL_TYPE_FWHT_PARAMS;
+ 		break;
++	case V4L2_CID_MPEG_VIDEO_H264_SPS:
++		*type = V4L2_CTRL_TYPE_H264_SPS;
++		break;
++	case V4L2_CID_MPEG_VIDEO_H264_PPS:
++		*type = V4L2_CTRL_TYPE_H264_PPS;
++		break;
++	case V4L2_CID_MPEG_VIDEO_H264_SCALING_MATRIX:
++		*type = V4L2_CTRL_TYPE_H264_SCALING_MATRIX;
++		break;
++	case V4L2_CID_MPEG_VIDEO_H264_SLICE_PARAMS:
++		*type = V4L2_CTRL_TYPE_H264_SLICE_PARAMS;
++		break;
++	case V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS:
++		*type = V4L2_CTRL_TYPE_H264_DECODE_PARAMS;
++		break;
+ 	default:
+ 		*type = V4L2_CTRL_TYPE_INTEGER;
+ 		break;
+@@ -1670,6 +1713,13 @@ static int std_validate(const struct v4l2_ctrl *ctrl, u32 idx,
+ 	case V4L2_CTRL_TYPE_FWHT_PARAMS:
+ 		return 0;
+ 
++	case V4L2_CTRL_TYPE_H264_SPS:
++	case V4L2_CTRL_TYPE_H264_PPS:
++	case V4L2_CTRL_TYPE_H264_SCALING_MATRIX:
++	case V4L2_CTRL_TYPE_H264_SLICE_PARAMS:
++	case V4L2_CTRL_TYPE_H264_DECODE_PARAMS:
++		return 0;
++
+ 	default:
+ 		return -EINVAL;
+ 	}
+@@ -2253,6 +2303,21 @@ static struct v4l2_ctrl *v4l2_ctrl_new(struct v4l2_ctrl_handler *hdl,
+ 	case V4L2_CTRL_TYPE_FWHT_PARAMS:
+ 		elem_size = sizeof(struct v4l2_ctrl_fwht_params);
+ 		break;
++	case V4L2_CTRL_TYPE_H264_SPS:
++		elem_size = sizeof(struct v4l2_ctrl_h264_sps);
++		break;
++	case V4L2_CTRL_TYPE_H264_PPS:
++		elem_size = sizeof(struct v4l2_ctrl_h264_pps);
++		break;
++	case V4L2_CTRL_TYPE_H264_SCALING_MATRIX:
++		elem_size = sizeof(struct v4l2_ctrl_h264_scaling_matrix);
++		break;
++	case V4L2_CTRL_TYPE_H264_SLICE_PARAMS:
++		elem_size = sizeof(struct v4l2_ctrl_h264_slice_params);
++		break;
++	case V4L2_CTRL_TYPE_H264_DECODE_PARAMS:
++		elem_size = sizeof(struct v4l2_ctrl_h264_decode_params);
++		break;
+ 	default:
+ 		if (type < V4L2_CTRL_COMPOUND_TYPES)
+ 			elem_size = sizeof(s32);
+diff --git a/drivers/media/v4l2-core/v4l2-ioctl.c b/drivers/media/v4l2-core/v4l2-ioctl.c
+index 6859bdac8..f9ec2d9ae 100644
+--- a/drivers/media/v4l2-core/v4l2-ioctl.c
++++ b/drivers/media/v4l2-core/v4l2-ioctl.c
+@@ -1321,6 +1321,7 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
+ 		case V4L2_PIX_FMT_H264:		descr = "H.264"; break;
+ 		case V4L2_PIX_FMT_H264_NO_SC:	descr = "H.264 (No Start Codes)"; break;
+ 		case V4L2_PIX_FMT_H264_MVC:	descr = "H.264 MVC"; break;
++		case V4L2_PIX_FMT_H264_SLICE_RAW:	descr = "H.264 Parsed Slice Data"; break;
+ 		case V4L2_PIX_FMT_H263:		descr = "H.263"; break;
+ 		case V4L2_PIX_FMT_MPEG1:	descr = "MPEG-1 ES"; break;
+ 		case V4L2_PIX_FMT_MPEG2:	descr = "MPEG-2 ES"; break;
+diff --git a/drivers/staging/media/sunxi/cedrus/Makefile b/drivers/staging/media/sunxi/cedrus/Makefile
+index 808842f01..c85ac6db0 100644
+--- a/drivers/staging/media/sunxi/cedrus/Makefile
++++ b/drivers/staging/media/sunxi/cedrus/Makefile
+@@ -1,4 +1,5 @@
+ # SPDX-License-Identifier: GPL-2.0
+ obj-$(CONFIG_VIDEO_SUNXI_CEDRUS) += sunxi-cedrus.o
+ 
+-sunxi-cedrus-y = cedrus.o cedrus_video.o cedrus_hw.o cedrus_dec.o cedrus_mpeg2.o
++sunxi-cedrus-y = cedrus.o cedrus_video.o cedrus_hw.o cedrus_dec.o \
++		 cedrus_mpeg2.o cedrus_h264.o
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus.c b/drivers/staging/media/sunxi/cedrus/cedrus.c
+index d0429c0e6..370937edf 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus.c
+@@ -40,6 +40,36 @@ static const struct cedrus_control cedrus_controls[] = {
+ 		.codec		= CEDRUS_CODEC_MPEG2,
+ 		.required	= false,
+ 	},
++	{
++		.id		= V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS,
++		.elem_size	= sizeof(struct v4l2_ctrl_h264_decode_params),
++		.codec		= CEDRUS_CODEC_H264,
++		.required	= true,
++	},
++	{
++		.id		= V4L2_CID_MPEG_VIDEO_H264_SLICE_PARAMS,
++		.elem_size	= sizeof(struct v4l2_ctrl_h264_slice_params),
++		.codec		= CEDRUS_CODEC_H264,
++		.required	= true,
++	},
++	{
++		.id		= V4L2_CID_MPEG_VIDEO_H264_SPS,
++		.elem_size	= sizeof(struct v4l2_ctrl_h264_sps),
++		.codec		= CEDRUS_CODEC_H264,
++		.required	= true,
++	},
++	{
++		.id		= V4L2_CID_MPEG_VIDEO_H264_PPS,
++		.elem_size	= sizeof(struct v4l2_ctrl_h264_pps),
++		.codec		= CEDRUS_CODEC_H264,
++		.required	= true,
++	},
++	{
++		.id		= V4L2_CID_MPEG_VIDEO_H264_SCALING_MATRIX,
++		.elem_size	= sizeof(struct v4l2_ctrl_h264_scaling_matrix),
++		.codec		= CEDRUS_CODEC_H264,
++		.required	= true,
++	},
+ };
+ 
+ #define CEDRUS_CONTROLS_COUNT	ARRAY_SIZE(cedrus_controls)
+@@ -278,6 +308,7 @@ static int cedrus_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	dev->dec_ops[CEDRUS_CODEC_MPEG2] = &cedrus_dec_ops_mpeg2;
++	dev->dec_ops[CEDRUS_CODEC_H264] = &cedrus_dec_ops_h264;
+ 
+ 	mutex_init(&dev->dev_mutex);
+ 
+@@ -369,36 +400,41 @@ static int cedrus_remove(struct platform_device *pdev)
+ }
+ 
+ static const struct cedrus_variant sun4i_a10_cedrus_variant = {
+-	/* No particular capability. */
++	.mod_rate	= 320000000,
+ };
+ 
+ static const struct cedrus_variant sun5i_a13_cedrus_variant = {
+-	/* No particular capability. */
++	.mod_rate	= 320000000,
+ };
+ 
+ static const struct cedrus_variant sun7i_a20_cedrus_variant = {
+-	/* No particular capability. */
++	.mod_rate	= 320000000,
+ };
+ 
+ static const struct cedrus_variant sun8i_a33_cedrus_variant = {
+ 	.capabilities	= CEDRUS_CAPABILITY_UNTILED,
++	.mod_rate	= 320000000,
+ };
+ 
+ static const struct cedrus_variant sun8i_h3_cedrus_variant = {
+ 	.capabilities	= CEDRUS_CAPABILITY_UNTILED,
++	.mod_rate	= 402000000,
+ };
+ 
+ static const struct cedrus_variant sun50i_a64_cedrus_variant = {
+ 	.capabilities	= CEDRUS_CAPABILITY_UNTILED,
++	.mod_rate	= 402000000,
+ };
+ 
+ static const struct cedrus_variant sun50i_h5_cedrus_variant = {
+ 	.capabilities	= CEDRUS_CAPABILITY_UNTILED,
++	.mod_rate	= 402000000,
+ };
+ 
+ static const struct cedrus_variant sun50i_h6_cedrus_variant = {
+ 	.capabilities	= CEDRUS_CAPABILITY_UNTILED,
+ 	.quirks		= CEDRUS_QUIRK_NO_DMA_OFFSET,
++	.mod_rate	= 600000000,
+ };
+ 
+ static const struct of_device_id cedrus_dt_match[] = {
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus.h b/drivers/staging/media/sunxi/cedrus/cedrus.h
+index c57c04b41..3f476d0fd 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus.h
++++ b/drivers/staging/media/sunxi/cedrus/cedrus.h
+@@ -32,7 +32,7 @@
+ 
+ enum cedrus_codec {
+ 	CEDRUS_CODEC_MPEG2,
+-
++	CEDRUS_CODEC_H264,
+ 	CEDRUS_CODEC_LAST,
+ };
+ 
+@@ -42,6 +42,12 @@ enum cedrus_irq_status {
+ 	CEDRUS_IRQ_OK,
+ };
+ 
++enum cedrus_h264_pic_type {
++	CEDRUS_H264_PIC_TYPE_FRAME	= 0,
++	CEDRUS_H264_PIC_TYPE_FIELD,
++	CEDRUS_H264_PIC_TYPE_MBAFF,
++};
++
+ struct cedrus_control {
+ 	u32			id;
+ 	u32			elem_size;
+@@ -49,6 +55,14 @@ struct cedrus_control {
+ 	unsigned char		required:1;
+ };
+ 
++struct cedrus_h264_run {
++	const struct v4l2_ctrl_h264_decode_params	*decode_params;
++	const struct v4l2_ctrl_h264_pps			*pps;
++	const struct v4l2_ctrl_h264_scaling_matrix	*scaling_matrix;
++	const struct v4l2_ctrl_h264_slice_params	*slice_params;
++	const struct v4l2_ctrl_h264_sps			*sps;
++};
++
+ struct cedrus_mpeg2_run {
+ 	const struct v4l2_ctrl_mpeg2_slice_params	*slice_params;
+ 	const struct v4l2_ctrl_mpeg2_quantization	*quantization;
+@@ -59,12 +73,20 @@ struct cedrus_run {
+ 	struct vb2_v4l2_buffer	*dst;
+ 
+ 	union {
++		struct cedrus_h264_run	h264;
+ 		struct cedrus_mpeg2_run	mpeg2;
+ 	};
+ };
+ 
+ struct cedrus_buffer {
+ 	struct v4l2_m2m_buffer          m2m_buf;
++
++	union {
++		struct {
++			unsigned int			position;
++			enum cedrus_h264_pic_type	pic_type;
++		} h264;
++	} codec;
+ };
+ 
+ struct cedrus_ctx {
+@@ -79,6 +101,19 @@ struct cedrus_ctx {
+ 	struct v4l2_ctrl		**ctrls;
+ 
+ 	struct vb2_buffer		*dst_bufs[VIDEO_MAX_FRAME];
++
++	union {
++		struct {
++			void		*mv_col_buf;
++			dma_addr_t	mv_col_buf_dma;
++			ssize_t		mv_col_buf_field_size;
++			ssize_t		mv_col_buf_size;
++			void		*pic_info_buf;
++			dma_addr_t	pic_info_buf_dma;
++			void		*neighbor_info_buf;
++			dma_addr_t	neighbor_info_buf_dma;
++		} h264;
++	} codec;
+ };
+ 
+ struct cedrus_dec_ops {
+@@ -94,6 +129,7 @@ struct cedrus_dec_ops {
+ struct cedrus_variant {
+ 	unsigned int	capabilities;
+ 	unsigned int	quirks;
++	unsigned int	mod_rate;
+ };
+ 
+ struct cedrus_dev {
+@@ -121,6 +157,7 @@ struct cedrus_dev {
+ };
+ 
+ extern struct cedrus_dec_ops cedrus_dec_ops_mpeg2;
++extern struct cedrus_dec_ops cedrus_dec_ops_h264;
+ 
+ static inline void cedrus_write(struct cedrus_dev *dev, u32 reg, u32 val)
+ {
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_dec.c b/drivers/staging/media/sunxi/cedrus/cedrus_dec.c
+index 4d6d602cd..bdad87eb9 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_dec.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_dec.c
+@@ -46,6 +46,19 @@ void cedrus_device_run(void *priv)
+ 			V4L2_CID_MPEG_VIDEO_MPEG2_QUANTIZATION);
+ 		break;
+ 
++	case V4L2_PIX_FMT_H264_SLICE_RAW:
++		run.h264.decode_params = cedrus_find_control_data(ctx,
++			V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS);
++		run.h264.pps = cedrus_find_control_data(ctx,
++			V4L2_CID_MPEG_VIDEO_H264_PPS);
++		run.h264.scaling_matrix = cedrus_find_control_data(ctx,
++			V4L2_CID_MPEG_VIDEO_H264_SCALING_MATRIX);
++		run.h264.slice_params = cedrus_find_control_data(ctx,
++			V4L2_CID_MPEG_VIDEO_H264_SLICE_PARAMS);
++		run.h264.sps = cedrus_find_control_data(ctx,
++			V4L2_CID_MPEG_VIDEO_H264_SPS);
++		break;
++
+ 	default:
+ 		break;
+ 	}
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+new file mode 100644
+index 000000000..a30bb283f
+--- /dev/null
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+@@ -0,0 +1,576 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Cedrus VPU driver
++ *
++ * Copyright (c) 2013 Jens Kuske <jenskuske@gmail.com>
++ * Copyright (c) 2018 Bootlin
++ */
++
++#include <linux/types.h>
++
++#include <media/videobuf2-dma-contig.h>
++
++#include "cedrus.h"
++#include "cedrus_hw.h"
++#include "cedrus_regs.h"
++
++enum cedrus_h264_sram_off {
++	CEDRUS_SRAM_H264_PRED_WEIGHT_TABLE	= 0x000,
++	CEDRUS_SRAM_H264_FRAMEBUFFER_LIST	= 0x100,
++	CEDRUS_SRAM_H264_REF_LIST_0		= 0x190,
++	CEDRUS_SRAM_H264_REF_LIST_1		= 0x199,
++	CEDRUS_SRAM_H264_SCALING_LIST_8x8_0	= 0x200,
++	CEDRUS_SRAM_H264_SCALING_LIST_8x8_1	= 0x210,
++	CEDRUS_SRAM_H264_SCALING_LIST_4x4	= 0x220,
++};
++
++struct cedrus_h264_sram_ref_pic {
++	__le32	top_field_order_cnt;
++	__le32	bottom_field_order_cnt;
++	__le32	frame_info;
++	__le32	luma_ptr;
++	__le32	chroma_ptr;
++	__le32	mv_col_top_ptr;
++	__le32	mv_col_bot_ptr;
++	__le32	reserved;
++} __packed;
++
++#define CEDRUS_H264_FRAME_NUM		18
++
++#define CEDRUS_NEIGHBOR_INFO_BUF_SIZE	(16 * SZ_1K)
++#define CEDRUS_PIC_INFO_BUF_SIZE	(128 * SZ_1K)
++
++static void cedrus_h264_write_sram(struct cedrus_dev *dev,
++				   enum cedrus_h264_sram_off off,
++				   const void *data, size_t len)
++{
++	const u32 *buffer = data;
++	size_t count = DIV_ROUND_UP(len, 4);
++
++	cedrus_write(dev, VE_AVC_SRAM_PORT_OFFSET, off << 2);
++
++	while (count--)
++		cedrus_write(dev, VE_AVC_SRAM_PORT_DATA, *buffer++);
++}
++
++static dma_addr_t cedrus_h264_mv_col_buf_addr(struct cedrus_ctx *ctx,
++					      unsigned int position,
++					      unsigned int field)
++{
++	dma_addr_t addr = ctx->codec.h264.mv_col_buf_dma;
++
++	/* Adjust for the position */
++	addr += position * ctx->codec.h264.mv_col_buf_field_size * 2;
++
++	/* Adjust for the field */
++	addr += field * ctx->codec.h264.mv_col_buf_field_size;
++
++	return addr;
++}
++
++static void cedrus_fill_ref_pic(struct cedrus_ctx *ctx,
++				struct cedrus_buffer *buf,
++				unsigned int top_field_order_cnt,
++				unsigned int bottom_field_order_cnt,
++				struct cedrus_h264_sram_ref_pic *pic)
++{
++	struct vb2_buffer *vbuf = &buf->m2m_buf.vb.vb2_buf;
++	unsigned int position = buf->codec.h264.position;
++
++	pic->top_field_order_cnt = cpu_to_le32(top_field_order_cnt);
++	pic->bottom_field_order_cnt = cpu_to_le32(bottom_field_order_cnt);
++	pic->frame_info = cpu_to_le32(buf->codec.h264.pic_type << 8);
++
++	pic->luma_ptr = cpu_to_le32(cedrus_buf_addr(vbuf, &ctx->dst_fmt, 0));
++	pic->chroma_ptr = cpu_to_le32(cedrus_buf_addr(vbuf, &ctx->dst_fmt, 1));
++	pic->mv_col_top_ptr =
++		cpu_to_le32(cedrus_h264_mv_col_buf_addr(ctx, position, 0));
++	pic->mv_col_bot_ptr =
++		cpu_to_le32(cedrus_h264_mv_col_buf_addr(ctx, position, 1));
++}
++
++static void cedrus_write_frame_list(struct cedrus_ctx *ctx,
++				    struct cedrus_run *run)
++{
++	struct cedrus_h264_sram_ref_pic pic_list[CEDRUS_H264_FRAME_NUM];
++	const struct v4l2_ctrl_h264_decode_params *decode = run->h264.decode_params;
++	const struct v4l2_ctrl_h264_slice_params *slice = run->h264.slice_params;
++	const struct v4l2_ctrl_h264_sps *sps = run->h264.sps;
++	struct vb2_queue *cap_q = &ctx->fh.m2m_ctx->cap_q_ctx.q;
++	struct cedrus_buffer *output_buf;
++	struct cedrus_dev *dev = ctx->dev;
++	unsigned long used_dpbs = 0;
++	unsigned int position;
++	unsigned int output = 0;
++	unsigned int i;
++
++	memset(pic_list, 0, sizeof(pic_list));
++
++	for (i = 0; i < ARRAY_SIZE(decode->dpb); i++) {
++		const struct v4l2_h264_dpb_entry *dpb = &decode->dpb[i];
++		struct cedrus_buffer *cedrus_buf;
++		int buf_idx;
++
++		if (!(dpb->flags & V4L2_H264_DPB_ENTRY_FLAG_VALID))
++			continue;
++
++		buf_idx = vb2_find_timestamp(cap_q, dpb->reference_ts, 0);
++		if (buf_idx < 0)
++			continue;
++
++		cedrus_buf = vb2_to_cedrus_buffer(ctx->dst_bufs[buf_idx]);
++		position = cedrus_buf->codec.h264.position;
++		used_dpbs |= BIT(position);
++
++		if (!(dpb->flags & V4L2_H264_DPB_ENTRY_FLAG_ACTIVE))
++			continue;
++
++		cedrus_fill_ref_pic(ctx, cedrus_buf,
++				    dpb->top_field_order_cnt,
++				    dpb->bottom_field_order_cnt,
++				    &pic_list[position]);
++
++		output = max(position, output);
++	}
++
++	position = find_next_zero_bit(&used_dpbs, CEDRUS_H264_FRAME_NUM,
++				      output);
++	if (position >= CEDRUS_H264_FRAME_NUM)
++		position = find_first_zero_bit(&used_dpbs, CEDRUS_H264_FRAME_NUM);
++
++	output_buf = vb2_to_cedrus_buffer(&run->dst->vb2_buf);
++	output_buf->codec.h264.position = position;
++
++	if (slice->flags & V4L2_H264_SLICE_FLAG_FIELD_PIC)
++		output_buf->codec.h264.pic_type = CEDRUS_H264_PIC_TYPE_FIELD;
++	else if (sps->flags & V4L2_H264_SPS_FLAG_MB_ADAPTIVE_FRAME_FIELD)
++		output_buf->codec.h264.pic_type = CEDRUS_H264_PIC_TYPE_MBAFF;
++	else
++		output_buf->codec.h264.pic_type = CEDRUS_H264_PIC_TYPE_FRAME;
++
++	cedrus_fill_ref_pic(ctx, output_buf,
++			    decode->top_field_order_cnt,
++			    decode->bottom_field_order_cnt,
++			    &pic_list[position]);
++
++	cedrus_h264_write_sram(dev, CEDRUS_SRAM_H264_FRAMEBUFFER_LIST,
++			       pic_list, sizeof(pic_list));
++
++	cedrus_write(dev, VE_H264_OUTPUT_FRAME_IDX, position);
++}
++
++#define CEDRUS_MAX_REF_IDX	32
++
++static void _cedrus_write_ref_list(struct cedrus_ctx *ctx,
++				   struct cedrus_run *run,
++				   const u8 *ref_list, u8 num_ref,
++				   enum cedrus_h264_sram_off sram)
++{
++	const struct v4l2_ctrl_h264_decode_params *decode = run->h264.decode_params;
++	struct vb2_queue *cap_q = &ctx->fh.m2m_ctx->cap_q_ctx.q;
++	struct cedrus_dev *dev = ctx->dev;
++	u8 sram_array[CEDRUS_MAX_REF_IDX];
++	unsigned int i;
++	size_t size;
++
++	memset(sram_array, 0, sizeof(sram_array));
++
++	for (i = 0; i < num_ref; i++) {
++		const struct v4l2_h264_dpb_entry *dpb;
++		const struct cedrus_buffer *cedrus_buf;
++		const struct vb2_v4l2_buffer *ref_buf;
++		unsigned int position;
++		int buf_idx;
++		u8 dpb_idx;
++
++		dpb_idx = ref_list[i];
++		dpb = &decode->dpb[dpb_idx];
++
++		if (!(dpb->flags & V4L2_H264_DPB_ENTRY_FLAG_ACTIVE))
++			continue;
++
++		buf_idx = vb2_find_timestamp(cap_q, dpb->reference_ts, 0);
++		if (buf_idx < 0)
++			continue;
++
++		ref_buf = to_vb2_v4l2_buffer(ctx->dst_bufs[buf_idx]);
++		cedrus_buf = vb2_v4l2_to_cedrus_buffer(ref_buf);
++		position = cedrus_buf->codec.h264.position;
++
++		sram_array[i] |= position << 1;
++		if (ref_buf->field == V4L2_FIELD_BOTTOM)
++			sram_array[i] |= BIT(0);
++	}
++
++	size = min_t(size_t, ALIGN(num_ref, 4), sizeof(sram_array));
++	cedrus_h264_write_sram(dev, sram, &sram_array, size);
++}
++
++static void cedrus_write_ref_list0(struct cedrus_ctx *ctx,
++				   struct cedrus_run *run)
++{
++	const struct v4l2_ctrl_h264_slice_params *slice = run->h264.slice_params;
++
++	_cedrus_write_ref_list(ctx, run,
++			       slice->ref_pic_list0,
++			       slice->num_ref_idx_l0_active_minus1 + 1,
++			       CEDRUS_SRAM_H264_REF_LIST_0);
++}
++
++static void cedrus_write_ref_list1(struct cedrus_ctx *ctx,
++				   struct cedrus_run *run)
++{
++	const struct v4l2_ctrl_h264_slice_params *slice = run->h264.slice_params;
++
++	_cedrus_write_ref_list(ctx, run,
++			       slice->ref_pic_list1,
++			       slice->num_ref_idx_l1_active_minus1 + 1,
++			       CEDRUS_SRAM_H264_REF_LIST_1);
++}
++
++static void cedrus_write_scaling_lists(struct cedrus_ctx *ctx,
++				       struct cedrus_run *run)
++{
++	const struct v4l2_ctrl_h264_scaling_matrix *scaling =
++		run->h264.scaling_matrix;
++	struct cedrus_dev *dev = ctx->dev;
++
++	cedrus_h264_write_sram(dev, CEDRUS_SRAM_H264_SCALING_LIST_8x8_0,
++			       scaling->scaling_list_8x8[0],
++			       sizeof(scaling->scaling_list_8x8[0]));
++
++	cedrus_h264_write_sram(dev, CEDRUS_SRAM_H264_SCALING_LIST_8x8_1,
++			       scaling->scaling_list_8x8[3],
++			       sizeof(scaling->scaling_list_8x8[3]));
++
++	cedrus_h264_write_sram(dev, CEDRUS_SRAM_H264_SCALING_LIST_4x4,
++			       scaling->scaling_list_4x4,
++			       sizeof(scaling->scaling_list_4x4));
++}
++
++static void cedrus_write_pred_weight_table(struct cedrus_ctx *ctx,
++					   struct cedrus_run *run)
++{
++	const struct v4l2_ctrl_h264_slice_params *slice =
++		run->h264.slice_params;
++	const struct v4l2_h264_pred_weight_table *pred_weight =
++		&slice->pred_weight_table;
++	struct cedrus_dev *dev = ctx->dev;
++	int i, j, k;
++
++	cedrus_write(dev, VE_H264_SHS_WP,
++		     ((pred_weight->chroma_log2_weight_denom & 0x7) << 4) |
++		     ((pred_weight->luma_log2_weight_denom & 0x7) << 0));
++
++	cedrus_write(dev, VE_AVC_SRAM_PORT_OFFSET,
++		     CEDRUS_SRAM_H264_PRED_WEIGHT_TABLE << 2);
++
++	for (i = 0; i < ARRAY_SIZE(pred_weight->weight_factors); i++) {
++		const struct v4l2_h264_weight_factors *factors =
++			&pred_weight->weight_factors[i];
++
++		for (j = 0; j < ARRAY_SIZE(factors->luma_weight); j++) {
++			u32 val;
++
++			val = (((u32)factors->luma_offset[j] & 0x1ff) << 16) |
++				(factors->luma_weight[j] & 0x1ff);
++			cedrus_write(dev, VE_AVC_SRAM_PORT_DATA, val);
++		}
++
++		for (j = 0; j < ARRAY_SIZE(factors->chroma_weight); j++) {
++			for (k = 0; k < ARRAY_SIZE(factors->chroma_weight[0]); k++) {
++				u32 val;
++
++				val = (((u32)factors->chroma_offset[j][k] & 0x1ff) << 16) |
++					(factors->chroma_weight[j][k] & 0x1ff);
++				cedrus_write(dev, VE_AVC_SRAM_PORT_DATA, val);
++			}
++		}
++	}
++}
++
++static void cedrus_set_params(struct cedrus_ctx *ctx,
++			      struct cedrus_run *run)
++{
++	const struct v4l2_ctrl_h264_decode_params *decode = run->h264.decode_params;
++	const struct v4l2_ctrl_h264_slice_params *slice = run->h264.slice_params;
++	const struct v4l2_ctrl_h264_pps *pps = run->h264.pps;
++	const struct v4l2_ctrl_h264_sps *sps = run->h264.sps;
++	struct vb2_buffer *src_buf = &run->src->vb2_buf;
++	struct cedrus_dev *dev = ctx->dev;
++	dma_addr_t src_buf_addr;
++	u32 offset = slice->header_bit_size;
++	u32 len = (slice->size * 8) - offset;
++	u32 reg;
++
++	cedrus_write(dev, VE_H264_VLD_LEN, len);
++	cedrus_write(dev, VE_H264_VLD_OFFSET, offset);
++
++	src_buf_addr = vb2_dma_contig_plane_dma_addr(src_buf, 0);
++	cedrus_write(dev, VE_H264_VLD_END,
++		     src_buf_addr + vb2_get_plane_payload(src_buf, 0));
++	cedrus_write(dev, VE_H264_VLD_ADDR,
++		     VE_H264_VLD_ADDR_VAL(src_buf_addr) |
++		     VE_H264_VLD_ADDR_FIRST | VE_H264_VLD_ADDR_VALID |
++		     VE_H264_VLD_ADDR_LAST);
++
++	/*
++	 * FIXME: Since the bitstream parsing is done in software, and
++	 * in userspace, this shouldn't be needed anymore. But it
++	 * turns out that removing it breaks the decoding process,
++	 * without any clear indication why.
++	 */
++	cedrus_write(dev, VE_H264_TRIGGER_TYPE,
++		     VE_H264_TRIGGER_TYPE_INIT_SWDEC);
++
++	if (((pps->flags & V4L2_H264_PPS_FLAG_WEIGHTED_PRED) &&
++	     (slice->slice_type == V4L2_H264_SLICE_TYPE_P ||
++	      slice->slice_type == V4L2_H264_SLICE_TYPE_SP)) ||
++	    (pps->weighted_bipred_idc == 1 &&
++	     slice->slice_type == V4L2_H264_SLICE_TYPE_B))
++		cedrus_write_pred_weight_table(ctx, run);
++
++	if ((slice->slice_type == V4L2_H264_SLICE_TYPE_P) ||
++	    (slice->slice_type == V4L2_H264_SLICE_TYPE_SP) ||
++	    (slice->slice_type == V4L2_H264_SLICE_TYPE_B))
++		cedrus_write_ref_list0(ctx, run);
++
++	if (slice->slice_type == V4L2_H264_SLICE_TYPE_B)
++		cedrus_write_ref_list1(ctx, run);
++
++	// picture parameters
++	reg = 0;
++	/*
++	 * FIXME: the kernel headers are allowing the default value to
++	 * be passed, but the libva doesn't give us that.
++	 */
++	reg |= (slice->num_ref_idx_l0_active_minus1 & 0x1f) << 10;
++	reg |= (slice->num_ref_idx_l1_active_minus1 & 0x1f) << 5;
++	reg |= (pps->weighted_bipred_idc & 0x3) << 2;
++	if (pps->flags & V4L2_H264_PPS_FLAG_ENTROPY_CODING_MODE)
++		reg |= VE_H264_PPS_ENTROPY_CODING_MODE;
++	if (pps->flags & V4L2_H264_PPS_FLAG_WEIGHTED_PRED)
++		reg |= VE_H264_PPS_WEIGHTED_PRED;
++	if (pps->flags & V4L2_H264_PPS_FLAG_CONSTRAINED_INTRA_PRED)
++		reg |= VE_H264_PPS_CONSTRAINED_INTRA_PRED;
++	if (pps->flags & V4L2_H264_PPS_FLAG_TRANSFORM_8X8_MODE)
++		reg |= VE_H264_PPS_TRANSFORM_8X8_MODE;
++	cedrus_write(dev, VE_H264_PPS, reg);
++
++	// sequence parameters
++	reg = 0;
++	reg |= (sps->chroma_format_idc & 0x7) << 19;
++	reg |= (sps->pic_width_in_mbs_minus1 & 0xff) << 8;
++	reg |= sps->pic_height_in_map_units_minus1 & 0xff;
++	if (sps->flags & V4L2_H264_SPS_FLAG_FRAME_MBS_ONLY)
++		reg |= VE_H264_SPS_MBS_ONLY;
++	if (sps->flags & V4L2_H264_SPS_FLAG_MB_ADAPTIVE_FRAME_FIELD)
++		reg |= VE_H264_SPS_MB_ADAPTIVE_FRAME_FIELD;
++	if (sps->flags & V4L2_H264_SPS_FLAG_DIRECT_8X8_INFERENCE)
++		reg |= VE_H264_SPS_DIRECT_8X8_INFERENCE;
++	cedrus_write(dev, VE_H264_SPS, reg);
++
++	// slice parameters
++	reg = 0;
++	reg |= decode->nal_ref_idc ? BIT(12) : 0;
++	reg |= (slice->slice_type & 0xf) << 8;
++	reg |= slice->cabac_init_idc & 0x3;
++	reg |= VE_H264_SHS_FIRST_SLICE_IN_PIC;
++	if (slice->flags & V4L2_H264_SLICE_FLAG_FIELD_PIC)
++		reg |= VE_H264_SHS_FIELD_PIC;
++	if (slice->flags & V4L2_H264_SLICE_FLAG_BOTTOM_FIELD)
++		reg |= VE_H264_SHS_BOTTOM_FIELD;
++	if (slice->flags & V4L2_H264_SLICE_FLAG_DIRECT_SPATIAL_MV_PRED)
++		reg |= VE_H264_SHS_DIRECT_SPATIAL_MV_PRED;
++	cedrus_write(dev, VE_H264_SHS, reg);
++
++	reg = 0;
++	reg |= VE_H264_SHS2_NUM_REF_IDX_ACTIVE_OVRD;
++	reg |= (slice->num_ref_idx_l0_active_minus1 & 0x1f) << 24;
++	reg |= (slice->num_ref_idx_l1_active_minus1 & 0x1f) << 16;
++	reg |= (slice->disable_deblocking_filter_idc & 0x3) << 8;
++	reg |= (slice->slice_alpha_c0_offset_div2 & 0xf) << 4;
++	reg |= slice->slice_beta_offset_div2 & 0xf;
++	cedrus_write(dev, VE_H264_SHS2, reg);
++
++	reg = 0;
++	reg |= (pps->second_chroma_qp_index_offset & 0x3f) << 16;
++	reg |= (pps->chroma_qp_index_offset & 0x3f) << 8;
++	reg |= (pps->pic_init_qp_minus26 + 26 + slice->slice_qp_delta) & 0x3f;
++	cedrus_write(dev, VE_H264_SHS_QP, reg);
++
++	// clear status flags
++	cedrus_write(dev, VE_H264_STATUS, cedrus_read(dev, VE_H264_STATUS));
++
++	// enable int
++	cedrus_write(dev, VE_H264_CTRL,
++		     VE_H264_CTRL_SLICE_DECODE_INT |
++		     VE_H264_CTRL_DECODE_ERR_INT |
++		     VE_H264_CTRL_VLD_DATA_REQ_INT);
++}
++
++static enum cedrus_irq_status
++cedrus_h264_irq_status(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++	u32 reg = cedrus_read(dev, VE_H264_STATUS);
++
++	if (reg & (VE_H264_STATUS_DECODE_ERR_INT |
++		   VE_H264_STATUS_VLD_DATA_REQ_INT))
++		return CEDRUS_IRQ_ERROR;
++
++	if (reg & VE_H264_CTRL_SLICE_DECODE_INT)
++		return CEDRUS_IRQ_OK;
++
++	return CEDRUS_IRQ_NONE;
++}
++
++static void cedrus_h264_irq_clear(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++
++	cedrus_write(dev, VE_H264_STATUS,
++		     VE_H264_STATUS_INT_MASK);
++}
++
++static void cedrus_h264_irq_disable(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++	u32 reg = cedrus_read(dev, VE_H264_CTRL);
++
++	cedrus_write(dev, VE_H264_CTRL,
++		     reg & ~VE_H264_CTRL_INT_MASK);
++}
++
++static void cedrus_h264_setup(struct cedrus_ctx *ctx,
++			      struct cedrus_run *run)
++{
++	struct cedrus_dev *dev = ctx->dev;
++
++	cedrus_engine_enable(dev, CEDRUS_CODEC_H264);
++
++	cedrus_write(dev, VE_H264_SDROT_CTRL, 0);
++	cedrus_write(dev, VE_H264_EXTRA_BUFFER1,
++		     ctx->codec.h264.pic_info_buf_dma);
++	cedrus_write(dev, VE_H264_EXTRA_BUFFER2,
++		     ctx->codec.h264.neighbor_info_buf_dma);
++
++	cedrus_write_scaling_lists(ctx, run);
++	cedrus_write_frame_list(ctx, run);
++
++	cedrus_set_params(ctx, run);
++}
++
++static int cedrus_h264_start(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++	unsigned int field_size;
++	unsigned int mv_col_size;
++	int ret;
++
++	/*
++	 * FIXME: It seems that the H6 cedarX code is using a formula
++	 * here based on the size of the frame, while all the older
++	 * code is using a fixed size, so that might need to be
++	 * changed at some point.
++	 */
++	ctx->codec.h264.pic_info_buf =
++		dma_alloc_coherent(dev->dev, CEDRUS_PIC_INFO_BUF_SIZE,
++				   &ctx->codec.h264.pic_info_buf_dma,
++				   GFP_KERNEL);
++	if (!ctx->codec.h264.pic_info_buf)
++		return -ENOMEM;
++
++	/*
++	 * That buffer is supposed to be 16kiB in size, and be aligned
++	 * on 16kiB as well. However, dma_alloc_coherent provides the
++	 * guarantee that we'll have a CPU and DMA address aligned on
++	 * the smallest page order that is greater to the requested
++	 * size, so we don't have to overallocate.
++	 */
++	ctx->codec.h264.neighbor_info_buf =
++		dma_alloc_coherent(dev->dev, CEDRUS_NEIGHBOR_INFO_BUF_SIZE,
++				   &ctx->codec.h264.neighbor_info_buf_dma,
++				   GFP_KERNEL);
++	if (!ctx->codec.h264.neighbor_info_buf) {
++		ret = -ENOMEM;
++		goto err_pic_buf;
++	}
++
++	field_size = DIV_ROUND_UP(ctx->src_fmt.width, 16) *
++		DIV_ROUND_UP(ctx->src_fmt.height, 16) * 16;
++
++	/*
++	 * FIXME: This is actually conditional to
++	 * V4L2_H264_SPS_FLAG_DIRECT_8X8_INFERENCE not being set, we
++	 * might have to rework this if memory efficiency ever is
++	 * something we need to work on.
++	 */
++	field_size = field_size * 2;
++
++	/*
++	 * FIXME: This is actually conditional to
++	 * V4L2_H264_SPS_FLAG_FRAME_MBS_ONLY not being set, we might
++	 * have to rework this if memory efficiency ever is something
++	 * we need to work on.
++	 */
++	field_size = field_size * 2;
++	ctx->codec.h264.mv_col_buf_field_size = field_size;
++
++	mv_col_size = field_size * 2 * CEDRUS_H264_FRAME_NUM;
++	ctx->codec.h264.mv_col_buf_size = mv_col_size;
++	ctx->codec.h264.mv_col_buf = dma_alloc_coherent(dev->dev,
++							ctx->codec.h264.mv_col_buf_size,
++							&ctx->codec.h264.mv_col_buf_dma,
++							GFP_KERNEL);
++	if (!ctx->codec.h264.mv_col_buf) {
++		ret = -ENOMEM;
++		goto err_neighbor_buf;
++	}
++
++	return 0;
++
++err_neighbor_buf:
++	dma_free_coherent(dev->dev, CEDRUS_NEIGHBOR_INFO_BUF_SIZE,
++			  ctx->codec.h264.neighbor_info_buf,
++			  ctx->codec.h264.neighbor_info_buf_dma);
++
++err_pic_buf:
++	dma_free_coherent(dev->dev, CEDRUS_PIC_INFO_BUF_SIZE,
++			  ctx->codec.h264.pic_info_buf,
++			  ctx->codec.h264.pic_info_buf_dma);
++	return ret;
++}
++
++static void cedrus_h264_stop(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++
++	dma_free_coherent(dev->dev, ctx->codec.h264.mv_col_buf_size,
++			  ctx->codec.h264.mv_col_buf,
++			  ctx->codec.h264.mv_col_buf_dma);
++	dma_free_coherent(dev->dev, CEDRUS_NEIGHBOR_INFO_BUF_SIZE,
++			  ctx->codec.h264.neighbor_info_buf,
++			  ctx->codec.h264.neighbor_info_buf_dma);
++	dma_free_coherent(dev->dev, CEDRUS_PIC_INFO_BUF_SIZE,
++			  ctx->codec.h264.pic_info_buf,
++			  ctx->codec.h264.pic_info_buf_dma);
++}
++
++static void cedrus_h264_trigger(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++
++	cedrus_write(dev, VE_H264_TRIGGER_TYPE,
++		     VE_H264_TRIGGER_TYPE_AVC_SLICE_DECODE);
++}
++
++struct cedrus_dec_ops cedrus_dec_ops_h264 = {
++	.irq_clear	= cedrus_h264_irq_clear,
++	.irq_disable	= cedrus_h264_irq_disable,
++	.irq_status	= cedrus_h264_irq_status,
++	.setup		= cedrus_h264_setup,
++	.start		= cedrus_h264_start,
++	.stop		= cedrus_h264_stop,
++	.trigger	= cedrus_h264_trigger,
++};
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_hw.c b/drivers/staging/media/sunxi/cedrus/cedrus_hw.c
+index fbfff7c1c..c34aec7c6 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_hw.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_hw.c
+@@ -46,6 +46,10 @@ int cedrus_engine_enable(struct cedrus_dev *dev, enum cedrus_codec codec)
+ 		reg |= VE_MODE_DEC_MPEG;
+ 		break;
+ 
++	case CEDRUS_CODEC_H264:
++		reg |= VE_MODE_DEC_H264;
++		break;
++
+ 	default:
+ 		return -EINVAL;
+ 	}
+@@ -236,7 +240,7 @@ int cedrus_hw_probe(struct cedrus_dev *dev)
+ 		goto err_sram;
+ 	}
+ 
+-	ret = clk_set_rate(dev->mod_clk, CEDRUS_CLOCK_RATE_DEFAULT);
++	ret = clk_set_rate(dev->mod_clk, variant->mod_rate);
+ 	if (ret) {
+ 		dev_err(dev->dev, "Failed to set clock rate\n");
+ 
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_hw.h b/drivers/staging/media/sunxi/cedrus/cedrus_hw.h
+index b43c77d54..27d088239 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_hw.h
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_hw.h
+@@ -16,8 +16,6 @@
+ #ifndef _CEDRUS_HW_H_
+ #define _CEDRUS_HW_H_
+ 
+-#define CEDRUS_CLOCK_RATE_DEFAULT	320000000
+-
+ int cedrus_engine_enable(struct cedrus_dev *dev, enum cedrus_codec codec);
+ void cedrus_engine_disable(struct cedrus_dev *dev);
+ 
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_regs.h b/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
+index de2d6b6f6..3e9931416 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
+@@ -232,4 +232,95 @@
+ #define VE_DEC_MPEG_ROT_LUMA			(VE_ENGINE_DEC_MPEG + 0xcc)
+ #define VE_DEC_MPEG_ROT_CHROMA			(VE_ENGINE_DEC_MPEG + 0xd0)
+ 
++#define VE_H264_SPS			0x200
++#define VE_H264_SPS_MBS_ONLY			BIT(18)
++#define VE_H264_SPS_MB_ADAPTIVE_FRAME_FIELD	BIT(17)
++#define VE_H264_SPS_DIRECT_8X8_INFERENCE	BIT(16)
++
++#define VE_H264_PPS			0x204
++#define VE_H264_PPS_ENTROPY_CODING_MODE		BIT(15)
++#define VE_H264_PPS_WEIGHTED_PRED		BIT(4)
++#define VE_H264_PPS_CONSTRAINED_INTRA_PRED	BIT(1)
++#define VE_H264_PPS_TRANSFORM_8X8_MODE		BIT(0)
++
++#define VE_H264_SHS			0x208
++#define VE_H264_SHS_FIRST_SLICE_IN_PIC		BIT(5)
++#define VE_H264_SHS_FIELD_PIC			BIT(4)
++#define VE_H264_SHS_BOTTOM_FIELD		BIT(3)
++#define VE_H264_SHS_DIRECT_SPATIAL_MV_PRED	BIT(2)
++
++#define VE_H264_SHS2			0x20c
++#define VE_H264_SHS2_NUM_REF_IDX_ACTIVE_OVRD	BIT(12)
++
++#define VE_H264_SHS_WP			0x210
++
++#define VE_H264_SHS_QP			0x21c
++#define VE_H264_SHS_QP_SCALING_MATRIX_DEFAULT	BIT(24)
++
++#define VE_H264_CTRL			0x220
++#define VE_H264_CTRL_VLD_DATA_REQ_INT		BIT(2)
++#define VE_H264_CTRL_DECODE_ERR_INT		BIT(1)
++#define VE_H264_CTRL_SLICE_DECODE_INT		BIT(0)
++
++#define VE_H264_CTRL_INT_MASK		(VE_H264_CTRL_VLD_DATA_REQ_INT | \
++					 VE_H264_CTRL_DECODE_ERR_INT | \
++					 VE_H264_CTRL_SLICE_DECODE_INT)
++
++#define VE_H264_TRIGGER_TYPE		0x224
++#define VE_H264_TRIGGER_TYPE_AVC_SLICE_DECODE	(8 << 0)
++#define VE_H264_TRIGGER_TYPE_INIT_SWDEC		(7 << 0)
++
++#define VE_H264_STATUS			0x228
++#define VE_H264_STATUS_VLD_DATA_REQ_INT		VE_H264_CTRL_VLD_DATA_REQ_INT
++#define VE_H264_STATUS_DECODE_ERR_INT		VE_H264_CTRL_DECODE_ERR_INT
++#define VE_H264_STATUS_SLICE_DECODE_INT		VE_H264_CTRL_SLICE_DECODE_INT
++
++#define VE_H264_STATUS_INT_MASK			VE_H264_CTRL_INT_MASK
++
++#define VE_H264_CUR_MB_NUM		0x22c
++
++#define VE_H264_VLD_ADDR		0x230
++#define VE_H264_VLD_ADDR_FIRST			BIT(30)
++#define VE_H264_VLD_ADDR_LAST			BIT(29)
++#define VE_H264_VLD_ADDR_VALID			BIT(28)
++#define VE_H264_VLD_ADDR_VAL(x)			(((x) & 0x0ffffff0) | ((x) >> 28))
++
++#define VE_H264_VLD_OFFSET		0x234
++#define VE_H264_VLD_LEN			0x238
++#define VE_H264_VLD_END			0x23c
++#define VE_H264_SDROT_CTRL		0x240
++#define VE_H264_OUTPUT_FRAME_IDX	0x24c
++#define VE_H264_EXTRA_BUFFER1		0x250
++#define VE_H264_EXTRA_BUFFER2		0x254
++#define VE_H264_BASIC_BITS		0x2dc
++#define VE_AVC_SRAM_PORT_OFFSET		0x2e0
++#define VE_AVC_SRAM_PORT_DATA		0x2e4
++
++#define VE_ISP_INPUT_SIZE		0xa00
++#define VE_ISP_INPUT_STRIDE		0xa04
++#define VE_ISP_CTRL			0xa08
++#define VE_ISP_INPUT_LUMA		0xa78
++#define VE_ISP_INPUT_CHROMA		0xa7c
++
++#define VE_AVC_PARAM			0xb04
++#define VE_AVC_QP			0xb08
++#define VE_AVC_MOTION_EST		0xb10
++#define VE_AVC_CTRL			0xb14
++#define VE_AVC_TRIGGER			0xb18
++#define VE_AVC_STATUS			0xb1c
++#define VE_AVC_BASIC_BITS		0xb20
++#define VE_AVC_UNK_BUF			0xb60
++#define VE_AVC_VLE_ADDR			0xb80
++#define VE_AVC_VLE_END			0xb84
++#define VE_AVC_VLE_OFFSET		0xb88
++#define VE_AVC_VLE_MAX			0xb8c
++#define VE_AVC_VLE_LENGTH		0xb90
++#define VE_AVC_REF_LUMA			0xba0
++#define VE_AVC_REF_CHROMA		0xba4
++#define VE_AVC_REC_LUMA			0xbb0
++#define VE_AVC_REC_CHROMA		0xbb4
++#define VE_AVC_REF_SLUMA		0xbb8
++#define VE_AVC_REC_SLUMA		0xbbc
++#define VE_AVC_MB_INFO			0xbc0
++
+ #endif
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_video.c b/drivers/staging/media/sunxi/cedrus/cedrus_video.c
+index 9673874ec..e2b530b1a 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_video.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_video.c
+@@ -37,6 +37,10 @@ static struct cedrus_format cedrus_formats[] = {
+ 		.pixelformat	= V4L2_PIX_FMT_MPEG2_SLICE,
+ 		.directions	= CEDRUS_DECODE_SRC,
+ 	},
++	{
++		.pixelformat	= V4L2_PIX_FMT_H264_SLICE_RAW,
++		.directions	= CEDRUS_DECODE_SRC,
++	},
+ 	{
+ 		.pixelformat	= V4L2_PIX_FMT_SUNXI_TILED_NV12,
+ 		.directions	= CEDRUS_DECODE_DST,
+@@ -100,6 +104,7 @@ static void cedrus_prepare_format(struct v4l2_pix_format *pix_fmt)
+ 
+ 	switch (pix_fmt->pixelformat) {
+ 	case V4L2_PIX_FMT_MPEG2_SLICE:
++	case V4L2_PIX_FMT_H264_SLICE_RAW:
+ 		/* Zero bytes per line for encoded source. */
+ 		bytesperline = 0;
+ 
+@@ -464,6 +469,10 @@ static int cedrus_start_streaming(struct vb2_queue *vq, unsigned int count)
+ 		ctx->current_codec = CEDRUS_CODEC_MPEG2;
+ 		break;
+ 
++	case V4L2_PIX_FMT_H264_SLICE_RAW:
++		ctx->current_codec = CEDRUS_CODEC_H264;
++		break;
++
+ 	default:
+ 		return -EINVAL;
+ 	}
+diff --git a/include/media/h264-ctrls.h b/include/media/h264-ctrls.h
+new file mode 100644
+index 000000000..e1404d78d
+--- /dev/null
++++ b/include/media/h264-ctrls.h
+@@ -0,0 +1,197 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * These are the H.264 state controls for use with stateless H.264
++ * codec drivers.
++ *
++ * It turns out that these structs are not stable yet and will undergo
++ * more changes. So keep them private until they are stable and ready to
++ * become part of the official public API.
++ */
++
++#ifndef _H264_CTRLS_H_
++#define _H264_CTRLS_H_
++
++#include <linux/videodev2.h>
++
++/* Our pixel format isn't stable at the moment */
++#define V4L2_PIX_FMT_H264_SLICE_RAW v4l2_fourcc('S', '2', '6', '4') /* H264 parsed slices */
++
++/*
++ * This is put insanely high to avoid conflicting with controls that
++ * would be added during the phase where those controls are not
++ * stable. It should be fixed eventually.
++ */
++#define V4L2_CID_MPEG_VIDEO_H264_SPS		(V4L2_CID_MPEG_BASE+1000)
++#define V4L2_CID_MPEG_VIDEO_H264_PPS		(V4L2_CID_MPEG_BASE+1001)
++#define V4L2_CID_MPEG_VIDEO_H264_SCALING_MATRIX	(V4L2_CID_MPEG_BASE+1002)
++#define V4L2_CID_MPEG_VIDEO_H264_SLICE_PARAMS	(V4L2_CID_MPEG_BASE+1003)
++#define V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS	(V4L2_CID_MPEG_BASE+1004)
++
++/* enum v4l2_ctrl_type type values */
++#define V4L2_CTRL_TYPE_H264_SPS			0x0110
++#define V4L2_CTRL_TYPE_H264_PPS			0x0111
++#define V4L2_CTRL_TYPE_H264_SCALING_MATRIX	0x0112
++#define V4L2_CTRL_TYPE_H264_SLICE_PARAMS	0x0113
++#define V4L2_CTRL_TYPE_H264_DECODE_PARAMS	0x0114
++
++#define V4L2_H264_SPS_CONSTRAINT_SET0_FLAG			0x01
++#define V4L2_H264_SPS_CONSTRAINT_SET1_FLAG			0x02
++#define V4L2_H264_SPS_CONSTRAINT_SET2_FLAG			0x04
++#define V4L2_H264_SPS_CONSTRAINT_SET3_FLAG			0x08
++#define V4L2_H264_SPS_CONSTRAINT_SET4_FLAG			0x10
++#define V4L2_H264_SPS_CONSTRAINT_SET5_FLAG			0x20
++
++#define V4L2_H264_SPS_FLAG_SEPARATE_COLOUR_PLANE		0x01
++#define V4L2_H264_SPS_FLAG_QPPRIME_Y_ZERO_TRANSFORM_BYPASS	0x02
++#define V4L2_H264_SPS_FLAG_DELTA_PIC_ORDER_ALWAYS_ZERO		0x04
++#define V4L2_H264_SPS_FLAG_GAPS_IN_FRAME_NUM_VALUE_ALLOWED	0x08
++#define V4L2_H264_SPS_FLAG_FRAME_MBS_ONLY			0x10
++#define V4L2_H264_SPS_FLAG_MB_ADAPTIVE_FRAME_FIELD		0x20
++#define V4L2_H264_SPS_FLAG_DIRECT_8X8_INFERENCE			0x40
++
++struct v4l2_ctrl_h264_sps {
++	__u8 profile_idc;
++	__u8 constraint_set_flags;
++	__u8 level_idc;
++	__u8 seq_parameter_set_id;
++	__u8 chroma_format_idc;
++	__u8 bit_depth_luma_minus8;
++	__u8 bit_depth_chroma_minus8;
++	__u8 log2_max_frame_num_minus4;
++	__u8 pic_order_cnt_type;
++	__u8 log2_max_pic_order_cnt_lsb_minus4;
++	__u8 max_num_ref_frames;
++	__u8 num_ref_frames_in_pic_order_cnt_cycle;
++	__s32 offset_for_ref_frame[255];
++	__s32 offset_for_non_ref_pic;
++	__s32 offset_for_top_to_bottom_field;
++	__u16 pic_width_in_mbs_minus1;
++	__u16 pic_height_in_map_units_minus1;
++	__u32 flags;
++};
++
++#define V4L2_H264_PPS_FLAG_ENTROPY_CODING_MODE				0x0001
++#define V4L2_H264_PPS_FLAG_BOTTOM_FIELD_PIC_ORDER_IN_FRAME_PRESENT	0x0002
++#define V4L2_H264_PPS_FLAG_WEIGHTED_PRED				0x0004
++#define V4L2_H264_PPS_FLAG_DEBLOCKING_FILTER_CONTROL_PRESENT		0x0008
++#define V4L2_H264_PPS_FLAG_CONSTRAINED_INTRA_PRED			0x0010
++#define V4L2_H264_PPS_FLAG_REDUNDANT_PIC_CNT_PRESENT			0x0020
++#define V4L2_H264_PPS_FLAG_TRANSFORM_8X8_MODE				0x0040
++#define V4L2_H264_PPS_FLAG_PIC_SCALING_MATRIX_PRESENT			0x0080
++
++struct v4l2_ctrl_h264_pps {
++	__u8 pic_parameter_set_id;
++	__u8 seq_parameter_set_id;
++	__u8 num_slice_groups_minus1;
++	__u8 num_ref_idx_l0_default_active_minus1;
++	__u8 num_ref_idx_l1_default_active_minus1;
++	__u8 weighted_bipred_idc;
++	__s8 pic_init_qp_minus26;
++	__s8 pic_init_qs_minus26;
++	__s8 chroma_qp_index_offset;
++	__s8 second_chroma_qp_index_offset;
++	__u16 flags;
++};
++
++struct v4l2_ctrl_h264_scaling_matrix {
++	__u8 scaling_list_4x4[6][16];
++	__u8 scaling_list_8x8[6][64];
++};
++
++struct v4l2_h264_weight_factors {
++	__s16 luma_weight[32];
++	__s16 luma_offset[32];
++	__s16 chroma_weight[32][2];
++	__s16 chroma_offset[32][2];
++};
++
++struct v4l2_h264_pred_weight_table {
++	__u16 luma_log2_weight_denom;
++	__u16 chroma_log2_weight_denom;
++	struct v4l2_h264_weight_factors weight_factors[2];
++};
++
++#define V4L2_H264_SLICE_TYPE_P				0
++#define V4L2_H264_SLICE_TYPE_B				1
++#define V4L2_H264_SLICE_TYPE_I				2
++#define V4L2_H264_SLICE_TYPE_SP				3
++#define V4L2_H264_SLICE_TYPE_SI				4
++
++#define V4L2_H264_SLICE_FLAG_FIELD_PIC			0x01
++#define V4L2_H264_SLICE_FLAG_BOTTOM_FIELD		0x02
++#define V4L2_H264_SLICE_FLAG_DIRECT_SPATIAL_MV_PRED	0x04
++#define V4L2_H264_SLICE_FLAG_SP_FOR_SWITCH		0x08
++
++struct v4l2_ctrl_h264_slice_params {
++	/* Size in bytes, including header */
++	__u32 size;
++	/* Offset in bits to slice_data() from the beginning of this slice. */
++	__u32 header_bit_size;
++
++	__u16 first_mb_in_slice;
++	__u8 slice_type;
++	__u8 pic_parameter_set_id;
++	__u8 colour_plane_id;
++	__u8 redundant_pic_cnt;
++	__u16 frame_num;
++	__u16 idr_pic_id;
++	__u16 pic_order_cnt_lsb;
++	__s32 delta_pic_order_cnt_bottom;
++	__s32 delta_pic_order_cnt0;
++	__s32 delta_pic_order_cnt1;
++
++	struct v4l2_h264_pred_weight_table pred_weight_table;
++	/* Size in bits of dec_ref_pic_marking() syntax element. */
++	__u32 dec_ref_pic_marking_bit_size;
++	/* Size in bits of pic order count syntax. */
++	__u32 pic_order_cnt_bit_size;
++
++	__u8 cabac_init_idc;
++	__s8 slice_qp_delta;
++	__s8 slice_qs_delta;
++	__u8 disable_deblocking_filter_idc;
++	__s8 slice_alpha_c0_offset_div2;
++	__s8 slice_beta_offset_div2;
++	__u8 num_ref_idx_l0_active_minus1;
++	__u8 num_ref_idx_l1_active_minus1;
++	__u32 slice_group_change_cycle;
++
++	/*
++	 * Entries on each list are indices into
++	 * v4l2_ctrl_h264_decode_params.dpb[].
++	 */
++	__u8 ref_pic_list0[32];
++	__u8 ref_pic_list1[32];
++
++	__u32 flags;
++};
++
++#define V4L2_H264_DPB_ENTRY_FLAG_VALID		0x01
++#define V4L2_H264_DPB_ENTRY_FLAG_ACTIVE		0x02
++#define V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM	0x04
++
++struct v4l2_h264_dpb_entry {
++	__u64 reference_ts;
++	__u16 frame_num;
++	__u16 pic_num;
++	/* Note that field is indicated by v4l2_buffer.field */
++	__s32 top_field_order_cnt;
++	__s32 bottom_field_order_cnt;
++	__u32 flags; /* V4L2_H264_DPB_ENTRY_FLAG_* */
++};
++
++#define V4L2_H264_DECODE_PARAM_FLAG_IDR_PIC	0x01
++
++struct v4l2_ctrl_h264_decode_params {
++	struct v4l2_h264_dpb_entry dpb[16];
++	__u16 num_slices;
++	__u16 nal_ref_idc;
++	__u8 ref_pic_list_p0[32];
++	__u8 ref_pic_list_b0[32];
++	__u8 ref_pic_list_b1[32];
++	__s32 top_field_order_cnt;
++	__s32 bottom_field_order_cnt;
++	__u32 flags; /* V4L2_H264_DECODE_PARAM_FLAG_* */
++};
++
++#endif
+diff --git a/include/media/v4l2-ctrls.h b/include/media/v4l2-ctrls.h
+index bfa2a4527..b4433483a 100644
+--- a/include/media/v4l2-ctrls.h
++++ b/include/media/v4l2-ctrls.h
+@@ -14,11 +14,12 @@
+ #include <media/media-request.h>
+ 
+ /*
+- * Include the mpeg2 and fwht stateless codec compound control definitions.
++ * Include the stateless codec compound control definitions.
+  * This will move to the public headers once this API is fully stable.
+  */
+ #include <media/mpeg2-ctrls.h>
+ #include <media/fwht-ctrls.h>
++#include <media/h264-ctrls.h>
+ 
+ /* forward references */
+ struct file;
+@@ -42,6 +43,11 @@ struct poll_table_struct;
+  * @p_mpeg2_slice_params:	Pointer to a MPEG2 slice parameters structure.
+  * @p_mpeg2_quantization:	Pointer to a MPEG2 quantization data structure.
+  * @p_fwht_params:		Pointer to a FWHT stateless parameters structure.
++ * @p_h264_sps:			Pointer to a struct v4l2_ctrl_h264_sps.
++ * @p_h264_pps:			Pointer to a struct v4l2_ctrl_h264_pps.
++ * @p_h264_scaling_matrix:	Pointer to a struct v4l2_ctrl_h264_scaling_matrix.
++ * @p_h264_slice_params:	Pointer to a struct v4l2_ctrl_h264_slice_params.
++ * @p_h264_decode_params:	Pointer to a struct v4l2_ctrl_h264_decode_params.
+  * @p:				Pointer to a compound value.
+  */
+ union v4l2_ctrl_ptr {
+@@ -54,6 +60,11 @@ union v4l2_ctrl_ptr {
+ 	struct v4l2_ctrl_mpeg2_slice_params *p_mpeg2_slice_params;
+ 	struct v4l2_ctrl_mpeg2_quantization *p_mpeg2_quantization;
+ 	struct v4l2_ctrl_fwht_params *p_fwht_params;
++	struct v4l2_ctrl_h264_sps *p_h264_sps;
++	struct v4l2_ctrl_h264_pps *p_h264_pps;
++	struct v4l2_ctrl_h264_scaling_matrix *p_h264_scaling_matrix;
++	struct v4l2_ctrl_h264_slice_params *p_h264_slice_params;
++	struct v4l2_ctrl_h264_decode_params *p_h264_decode_params;
+ 	void *p;
+ };
+ 
+diff --git a/include/uapi/linux/v4l2-controls.h b/include/uapi/linux/v4l2-controls.h
+index 37807f232..d9f2c76b7 100644
+--- a/include/uapi/linux/v4l2-controls.h
++++ b/include/uapi/linux/v4l2-controls.h
+@@ -404,6 +404,24 @@ enum v4l2_mpeg_video_multi_slice_mode {
+ #define V4L2_CID_MPEG_VIDEO_MV_V_SEARCH_RANGE		(V4L2_CID_MPEG_BASE+228)
+ #define V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME		(V4L2_CID_MPEG_BASE+229)
+ 
++/* CIDs for the MPEG-2 Part 2 (H.262) codec */
++#define V4L2_CID_MPEG_VIDEO_MPEG2_LEVEL			(V4L2_CID_MPEG_BASE+270)
++enum v4l2_mpeg_video_mpeg2_level {
++	V4L2_MPEG_VIDEO_MPEG2_LEVEL_LOW		= 0,
++	V4L2_MPEG_VIDEO_MPEG2_LEVEL_MAIN	= 1,
++	V4L2_MPEG_VIDEO_MPEG2_LEVEL_HIGH_1440	= 2,
++	V4L2_MPEG_VIDEO_MPEG2_LEVEL_HIGH	= 3,
++};
++#define V4L2_CID_MPEG_VIDEO_MPEG2_PROFILE		(V4L2_CID_MPEG_BASE+271)
++enum v4l2_mpeg_video_mpeg2_profile {
++	V4L2_MPEG_VIDEO_MPEG2_PROFILE_SIMPLE				= 0,
++	V4L2_MPEG_VIDEO_MPEG2_PROFILE_MAIN				= 1,
++	V4L2_MPEG_VIDEO_MPEG2_PROFILE_SNR_SCALABLE			= 2,
++	V4L2_MPEG_VIDEO_MPEG2_PROFILE_SPATIALLY_SCALABLE		= 3,
++	V4L2_MPEG_VIDEO_MPEG2_PROFILE_HIGH				= 4,
++	V4L2_MPEG_VIDEO_MPEG2_PROFILE_MULTIVIEW				= 5,
++};
++
+ /* CIDs for the FWHT codec as used by the vicodec driver. */
+ #define V4L2_CID_FWHT_I_FRAME_QP             (V4L2_CID_MPEG_BASE + 290)
+ #define V4L2_CID_FWHT_P_FRAME_QP             (V4L2_CID_MPEG_BASE + 291)
+-- 
+2.17.1
+

--- a/patch/kernel/sunxi-next-olinuxino/0152-cedrus-hevc.patch
+++ b/patch/kernel/sunxi-next-olinuxino/0152-cedrus-hevc.patch
@@ -1,0 +1,1927 @@
+From 8570e6a5376f00014ac27c15326a2f50c62c5304 Mon Sep 17 00:00:00 2001
+From: hehopmajieh <hehopmajieh@debian.bg>
+Date: Fri, 3 Jan 2020 23:23:41 +0200
+Subject: [PATCH 2/7] cedrus-hevc patch From
+ 2a7c76208e46bd164d7e968d063d870fcb1e9314 Mon Sep 17 00:00:00 2001 From: Paul
+ Kocialkowski <paul.kocialkowski@bootlin.com> Date: Fri, 24 May 2019 11:36:32
+ +0200 Subject: [PATCH 09/12] media: v4l: Add definitions for the HEVC slice
+ controls
+
+---
+ Documentation/media/uapi/v4l/biblio.rst       |   9 +
+ .../media/uapi/v4l/ext-ctrls-codec.rst        | 429 +++++++++++++-
+ .../media/uapi/v4l/pixfmt-compressed.rst      |  21 +
+ .../media/uapi/v4l/vidioc-queryctrl.rst       |  18 +
+ .../media/videodev2.h.rst.exceptions          |   3 +
+ drivers/media/v4l2-core/v4l2-ctrls.c          |  26 +
+ drivers/media/v4l2-core/v4l2-ioctl.c          |   1 +
+ drivers/staging/media/sunxi/cedrus/Makefile   |   2 +-
+ drivers/staging/media/sunxi/cedrus/cedrus.c   |  31 +-
+ drivers/staging/media/sunxi/cedrus/cedrus.h   |  18 +
+ .../staging/media/sunxi/cedrus/cedrus_dec.c   |   9 +
+ .../staging/media/sunxi/cedrus/cedrus_h265.c  | 532 ++++++++++++++++++
+ .../staging/media/sunxi/cedrus/cedrus_hw.c    |   4 +
+ .../staging/media/sunxi/cedrus/cedrus_regs.h  | 290 ++++++++++
+ .../staging/media/sunxi/cedrus/cedrus_video.c |  10 +
+ include/media/hevc-ctrls.h                    | 185 ++++++
+ include/media/v4l2-ctrls.h                    |   7 +
+ 17 files changed, 1587 insertions(+), 8 deletions(-)
+ create mode 100644 drivers/staging/media/sunxi/cedrus/cedrus_h265.c
+ create mode 100644 include/media/hevc-ctrls.h
+
+diff --git a/Documentation/media/uapi/v4l/biblio.rst b/Documentation/media/uapi/v4l/biblio.rst
+index 8f4eb8823..e38ef5ee4 100644
+--- a/Documentation/media/uapi/v4l/biblio.rst
++++ b/Documentation/media/uapi/v4l/biblio.rst
+@@ -131,6 +131,15 @@ ITU-T Rec. H.264 Specification (04/2017 Edition)
+ 
+ :author:    International Telecommunication Union (http://www.itu.ch)
+ 
++.. _hevc:
++
++ITU H.265/HEVC
++==============
++
++:title:     ITU-T Rec. H.265 | ISO/IEC 23008-2 "High Efficiency Video Coding"
++
++:author:    International Telecommunication Union (http://www.itu.ch), International Organisation for Standardisation (http://www.iso.ch)
++
+ .. _jfif:
+ 
+ JFIF
+diff --git a/Documentation/media/uapi/v4l/ext-ctrls-codec.rst b/Documentation/media/uapi/v4l/ext-ctrls-codec.rst
+index b0c178f0f..19e5bfba8 100644
+--- a/Documentation/media/uapi/v4l/ext-ctrls-codec.rst
++++ b/Documentation/media/uapi/v4l/ext-ctrls-codec.rst
+@@ -1981,9 +1981,9 @@ enum v4l2_mpeg_video_h264_hierarchical_coding_type -
+       - ``reference_ts``
+       - Timestamp of the V4L2 capture buffer to use as reference, used
+         with B-coded and P-coded frames. The timestamp refers to the
+-	``timestamp`` field in struct :c:type:`v4l2_buffer`. Use the
+-	:c:func:`v4l2_timeval_to_ns()` function to convert the struct
+-	:c:type:`timeval` in struct :c:type:`v4l2_buffer` to a __u64.
++        ``timestamp`` field in struct :c:type:`v4l2_buffer`. Use the
++        :c:func:`v4l2_timeval_to_ns()` function to convert the struct
++        :c:type:`timeval` in struct :c:type:`v4l2_buffer` to a __u64.
+     * - __u16
+       - ``frame_num``
+       -
+@@ -3291,3 +3291,426 @@ enum v4l2_mpeg_video_hevc_size_of_length_field -
+     Indicates whether to generate SPS and PPS at every IDR. Setting it to 0
+     disables generating SPS and PPS at every IDR. Setting it to one enables
+     generating SPS and PPS at every IDR.
++
++.. _v4l2-mpeg-hevc:
++
++``V4L2_CID_MPEG_VIDEO_HEVC_SPS (struct)``
++    Specifies the Sequence Parameter Set fields (as extracted from the
++    bitstream) for the associated HEVC slice data.
++    These bitstream parameters are defined according to :ref:`hevc`.
++    They are described in section 7.4.3.2 "Sequence parameter set RBSP
++    semantics" of the specification.
++
++.. c:type:: v4l2_ctrl_hevc_sps
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_ctrl_hevc_sps
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u8
++      - ``chroma_format_idc``
++      -
++    * - __u8
++      - ``separate_colour_plane_flag``
++      -
++    * - __u16
++      - ``pic_width_in_luma_samples``
++      -
++    * - __u16
++      - ``pic_height_in_luma_samples``
++      -
++    * - __u8
++      - ``bit_depth_luma_minus8``
++      -
++    * - __u8
++      - ``bit_depth_chroma_minus8``
++      -
++    * - __u8
++      - ``log2_max_pic_order_cnt_lsb_minus4``
++      -
++    * - __u8
++      - ``sps_max_dec_pic_buffering_minus1``
++      -
++    * - __u8
++      - ``sps_max_num_reorder_pics``
++      -
++    * - __u8
++      - ``sps_max_latency_increase_plus1``
++      -
++    * - __u8
++      - ``log2_min_luma_coding_block_size_minus3``
++      -
++    * - __u8
++      - ``log2_diff_max_min_luma_coding_block_size``
++      -
++    * - __u8
++      - ``log2_min_luma_transform_block_size_minus2``
++      -
++    * - __u8
++      - ``log2_diff_max_min_luma_transform_block_size``
++      -
++    * - __u8
++      - ``max_transform_hierarchy_depth_inter``
++      -
++    * - __u8
++      - ``max_transform_hierarchy_depth_intra``
++      -
++    * - __u8
++      - ``scaling_list_enabled_flag``
++      -
++    * - __u8
++      - ``amp_enabled_flag``
++      -
++    * - __u8
++      - ``sample_adaptive_offset_enabled_flag``
++      -
++    * - __u8
++      - ``pcm_enabled_flag``
++      -
++    * - __u8
++      - ``pcm_sample_bit_depth_luma_minus1``
++      -
++    * - __u8
++      - ``pcm_sample_bit_depth_chroma_minus1``
++      -
++    * - __u8
++      - ``log2_min_pcm_luma_coding_block_size_minus3``
++      -
++    * - __u8
++      - ``log2_diff_max_min_pcm_luma_coding_block_size``
++      -
++    * - __u8
++      - ``pcm_loop_filter_disabled_flag``
++      -
++    * - __u8
++      - ``num_short_term_ref_pic_sets``
++      -
++    * - __u8
++      - ``long_term_ref_pics_present_flag``
++      -
++    * - __u8
++      - ``num_long_term_ref_pics_sps``
++      -
++    * - __u8
++      - ``sps_temporal_mvp_enabled_flag``
++      -
++    * - __u8
++      - ``strong_intra_smoothing_enabled_flag``
++      -
++
++``V4L2_CID_MPEG_VIDEO_HEVC_PPS (struct)``
++    Specifies the Picture Parameter Set fields (as extracted from the
++    bitstream) for the associated HEVC slice data.
++    These bitstream parameters are defined according to :ref:`hevc`.
++    They are described in section 7.4.3.3 "Picture parameter set RBSP
++    semantics" of the specification.
++
++.. c:type:: v4l2_ctrl_hevc_pps
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_ctrl_hevc_pps
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u8
++      - ``dependent_slice_segment_flag``
++      -
++    * - __u8
++      - ``output_flag_present_flag``
++      -
++    * - __u8
++      - ``num_extra_slice_header_bits``
++      -
++    * - __u8
++      - ``sign_data_hiding_enabled_flag``
++      -
++    * - __u8
++      - ``cabac_init_present_flag``
++      -
++    * - __s8
++      - ``init_qp_minus26``
++      -
++    * - __u8
++      - ``constrained_intra_pred_flag``
++      -
++    * - __u8
++      - ``transform_skip_enabled_flag``
++      -
++    * - __u8
++      - ``cu_qp_delta_enabled_flag``
++      -
++    * - __u8
++      - ``diff_cu_qp_delta_depth``
++      -
++    * - __s8
++      - ``pps_cb_qp_offset``
++      -
++    * - __s8
++      - ``pps_cr_qp_offset``
++      -
++    * - __u8
++      - ``pps_slice_chroma_qp_offsets_present_flag``
++      -
++    * - __u8
++      - ``weighted_pred_flag``
++      -
++    * - __u8
++      - ``weighted_bipred_flag``
++      -
++    * - __u8
++      - ``transquant_bypass_enabled_flag``
++      -
++    * - __u8
++      - ``tiles_enabled_flag``
++      -
++    * - __u8
++      - ``entropy_coding_sync_enabled_flag``
++      -
++    * - __u8
++      - ``num_tile_columns_minus1``
++      -
++    * - __u8
++      - ``num_tile_rows_minus1``
++      -
++    * - __u8
++      - ``column_width_minus1[20]``
++      -
++    * - __u8
++      - ``row_height_minus1[22]``
++      -
++    * - __u8
++      - ``loop_filter_across_tiles_enabled_flag``
++      -
++    * - __u8
++      - ``pps_loop_filter_across_slices_enabled_flag``
++      -
++    * - __u8
++      - ``deblocking_filter_override_enabled_flag``
++      -
++    * - __u8
++      - ``pps_disable_deblocking_filter_flag``
++      -
++    * - __s8
++      - ``pps_beta_offset_div2``
++      -
++    * - __s8
++      - ``pps_tc_offset_div2``
++      -
++    * - __u8
++      - ``lists_modification_present_flag``
++      -
++    * - __u8
++      - ``log2_parallel_merge_level_minus2``
++      -
++    * - __u8
++      - ``slice_segment_header_extension_present_flag``
++      -
++
++``V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS (struct)``
++    Specifies various slice-specific parameters, especially from the NAL unit
++    header, general slice segment header and weighted prediction parameter
++    parts of the bitstream.
++    These bitstream parameters are defined according to :ref:`hevc`.
++    They are described in section 7.4.7 "General slice segment header
++    semantics" of the specification.
++
++.. c:type:: v4l2_ctrl_hevc_slice_params
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_ctrl_hevc_slice_params
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u32
++      - ``bit_size``
++      - Size (in bits) of the current slice data.
++    * - __u32
++      - ``data_bit_offset``
++      - Offset (in bits) to the video data in the current slice data.
++    * - __u8
++      - ``nal_unit_type``
++      -
++    * - __u8
++      - ``nuh_temporal_id_plus1``
++      -
++    * - __u8
++      - ``slice_type``
++      -
++	(V4L2_HEVC_SLICE_TYPE_I, V4L2_HEVC_SLICE_TYPE_P or
++	V4L2_HEVC_SLICE_TYPE_B).
++    * - __u8
++      - ``colour_plane_id``
++      -
++    * - __u16
++      - ``slice_pic_order_cnt``
++      -
++    * - __u8
++      - ``slice_sao_luma_flag``
++      -
++    * - __u8
++      - ``slice_sao_chroma_flag``
++      -
++    * - __u8
++      - ``slice_temporal_mvp_enabled_flag``
++      -
++    * - __u8
++      - ``num_ref_idx_l0_active_minus1``
++      -
++    * - __u8
++      - ``num_ref_idx_l1_active_minus1``
++      -
++    * - __u8
++      - ``mvd_l1_zero_flag``
++      -
++    * - __u8
++      - ``cabac_init_flag``
++      -
++    * - __u8
++      - ``collocated_from_l0_flag``
++      -
++    * - __u8
++      - ``collocated_ref_idx``
++      -
++    * - __u8
++      - ``five_minus_max_num_merge_cand``
++      -
++    * - __u8
++      - ``use_integer_mv_flag``
++      -
++    * - __s8
++      - ``slice_qp_delta``
++      -
++    * - __s8
++      - ``slice_cb_qp_offset``
++      -
++    * - __s8
++      - ``slice_cr_qp_offset``
++      -
++    * - __s8
++      - ``slice_act_y_qp_offset``
++      -
++    * - __s8
++      - ``slice_act_cb_qp_offset``
++      -
++    * - __s8
++      - ``slice_act_cr_qp_offset``
++      -
++    * - __u8
++      - ``slice_deblocking_filter_disabled_flag``
++      -
++    * - __s8
++      - ``slice_beta_offset_div2``
++      -
++    * - __s8
++      - ``slice_tc_offset_div2``
++      -
++    * - __u8
++      - ``slice_loop_filter_across_slices_enabled_flag``
++      -
++    * - __u8
++      - ``pic_struct``
++      -
++    * - struct :c:type:`v4l2_hevc_dpb_entry`
++      - ``dpb[V4L2_HEVC_DPB_ENTRIES_NUM_MAX]``
++      - The decoded picture buffer, for meta-data about reference frames.
++    * - __u8
++      - ``num_active_dpb_entries``
++      - The number of entries in ``dpb``.
++    * - __u8
++      - ``ref_idx_l0[V4L2_HEVC_DPB_ENTRIES_NUM_MAX]``
++      - The list of L0 reference elements as indices in the DPB.
++    * - __u8
++      - ``ref_idx_l1[V4L2_HEVC_DPB_ENTRIES_NUM_MAX]``
++      - The list of L1 reference elements as indices in the DPB.
++    * - __u8
++      - ``num_rps_poc_st_curr_before``
++      - The number of reference pictures in the short-term set that come before
++        the current frame.
++    * - __u8
++      - ``num_rps_poc_st_curr_after``
++      - The number of reference pictures in the short-term set that come after
++        the current frame.
++    * - __u8
++      - ``num_rps_poc_lt_curr``
++      - The number of reference pictures in the long-term set.
++    * - struct :c:type:`v4l2_hevc_pred_weight_table`
++      - ``pred_weight_table``
++      - The prediction weight coefficients for inter-picture prediction.
++
++.. c:type:: v4l2_hevc_dpb_entry
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_hevc_dpb_entry
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u64
++      - ``timestamp``
++      - Timestamp of the V4L2 capture buffer to use as reference, used
++        with B-coded and P-coded frames. The timestamp refers to the
++	``timestamp`` field in struct :c:type:`v4l2_buffer`. Use the
++	:c:func:`v4l2_timeval_to_ns()` function to convert the struct
++	:c:type:`timeval` in struct :c:type:`v4l2_buffer` to a __u64.
++    * - __u8
++      - ``rps``
++      - The reference set for the reference frame
++        (V4L2_HEVC_DPB_ENTRY_RPS_ST_CURR_BEFORE,
++        V4L2_HEVC_DPB_ENTRY_RPS_ST_CURR_AFTER or
++        V4L2_HEVC_DPB_ENTRY_RPS_LT_CURR)
++    * - __u8
++      - ``field_pic``
++      - Whether the reference is a field picture or a frame.
++    * - __u16
++      - ``pic_order_cnt[2]``
++      - The picture order count of the reference. Only the first element of the
++        array is used for frame pictures, while the first element identifies the
++        top field and the second the bottom field in field-coded pictures.
++
++.. c:type:: v4l2_hevc_pred_weight_table
++
++.. cssclass:: longtable
++
++.. flat-table:: struct v4l2_hevc_pred_weight_table
++    :header-rows:  0
++    :stub-columns: 0
++    :widths:       1 1 2
++
++    * - __u8
++      - ``luma_log2_weight_denom``
++      -
++    * - __s8
++      - ``delta_chroma_log2_weight_denom``
++      -
++    * - __s8
++      - ``delta_luma_weight_l0[V4L2_HEVC_DPB_ENTRIES_NUM_MAX]``
++      -
++    * - __s8
++      - ``luma_offset_l0[V4L2_HEVC_DPB_ENTRIES_NUM_MAX]``
++      -
++    * - __s8
++      - ``delta_chroma_weight_l0[V4L2_HEVC_DPB_ENTRIES_NUM_MAX][2]``
++      -
++    * - __s8
++      - ``chroma_offset_l0[V4L2_HEVC_DPB_ENTRIES_NUM_MAX][2]``
++      -
++    * - __s8
++      - ``delta_luma_weight_l1[V4L2_HEVC_DPB_ENTRIES_NUM_MAX]``
++      -
++    * - __s8
++      - ``luma_offset_l1[V4L2_HEVC_DPB_ENTRIES_NUM_MAX]``
++      -
++    * - __s8
++      - ``delta_chroma_weight_l1[V4L2_HEVC_DPB_ENTRIES_NUM_MAX][2]``
++      -
++    * - __s8
++      - ``chroma_offset_l1[V4L2_HEVC_DPB_ENTRIES_NUM_MAX][2]``
++      -
+diff --git a/Documentation/media/uapi/v4l/pixfmt-compressed.rst b/Documentation/media/uapi/v4l/pixfmt-compressed.rst
+index 4b701fc76..9d4195723 100644
+--- a/Documentation/media/uapi/v4l/pixfmt-compressed.rst
++++ b/Documentation/media/uapi/v4l/pixfmt-compressed.rst
+@@ -143,6 +143,27 @@ Compressed Formats
+       - ``V4L2_PIX_FMT_HEVC``
+       - 'HEVC'
+       - HEVC/H.265 video elementary stream.
++    * .. _V4L2-PIX-FMT-HEVC-SLICE:
++
++      - ``V4L2_PIX_FMT_HEVC_SLICE``
++      - 'S265'
++      - HEVC parsed slice data, as extracted from the HEVC bitstream.
++	This format is adapted for stateless video decoders that implement a
++	HEVC pipeline (using the :ref:`codec` and :ref:`media-request-api`).
++	Metadata associated with the frame to decode is required to be passed
++	through the following controls :
++        * ``V4L2_CID_MPEG_VIDEO_HEVC_SPS``
++        * ``V4L2_CID_MPEG_VIDEO_HEVC_PPS``
++        * ``V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS``
++	See the :ref:`associated Codec Control IDs <v4l2-mpeg-hevc>`.
++	Buffers associated with this pixel format must contain the appropriate
++	number of macroblocks to decode a full corresponding frame.
++
++	.. note::
++
++	   This format is not yet part of the public kernel API and it
++	   is expected to change.
++
+     * .. _V4L2-PIX-FMT-FWHT:
+ 
+       - ``V4L2_PIX_FMT_FWHT``
+diff --git a/Documentation/media/uapi/v4l/vidioc-queryctrl.rst b/Documentation/media/uapi/v4l/vidioc-queryctrl.rst
+index dc5006320..e090ef332 100644
+--- a/Documentation/media/uapi/v4l/vidioc-queryctrl.rst
++++ b/Documentation/media/uapi/v4l/vidioc-queryctrl.rst
+@@ -473,6 +473,24 @@ See also the examples in :ref:`control`.
+       - n/a
+       - A struct :c:type:`v4l2_ctrl_h264_decode_params`, containing H264
+ 	decode parameters for stateless video decoders.
++    * - ``V4L2_CTRL_TYPE_HEVC_SPS``
++      - n/a
++      - n/a
++      - n/a
++      - A struct :c:type:`v4l2_ctrl_hevc_sps`, containing HEVC Sequence
++	Parameter Set for stateless video decoders.
++    * - ``V4L2_CTRL_TYPE_HEVC_PPS``
++      - n/a
++      - n/a
++      - n/a
++      - A struct :c:type:`v4l2_ctrl_hevc_pps`, containing HEVC Picture
++	Parameter Set for stateless video decoders.
++    * - ``V4L2_CTRL_TYPE_HEVC_SLICE_PARAMS``
++      - n/a
++      - n/a
++      - n/a
++      - A struct :c:type:`v4l2_ctrl_hevc_slice_params`, containing HEVC
++	slice parameters for stateless video decoders.
+ 
+ .. tabularcolumns:: |p{6.6cm}|p{2.2cm}|p{8.7cm}|
+ 
+diff --git a/Documentation/media/videodev2.h.rst.exceptions b/Documentation/media/videodev2.h.rst.exceptions
+index 55cbe324b..afba7d719 100644
+--- a/Documentation/media/videodev2.h.rst.exceptions
++++ b/Documentation/media/videodev2.h.rst.exceptions
+@@ -141,6 +141,9 @@ replace symbol V4L2_CTRL_TYPE_H264_PPS :c:type:`v4l2_ctrl_type`
+ replace symbol V4L2_CTRL_TYPE_H264_SCALING_MATRIX :c:type:`v4l2_ctrl_type`
+ replace symbol V4L2_CTRL_TYPE_H264_SLICE_PARAMS :c:type:`v4l2_ctrl_type`
+ replace symbol V4L2_CTRL_TYPE_H264_DECODE_PARAMS :c:type:`v4l2_ctrl_type`
++replace symbol V4L2_CTRL_TYPE_HEVC_SPS :c:type:`v4l2_ctrl_type`
++replace symbol V4L2_CTRL_TYPE_HEVC_PPS :c:type:`v4l2_ctrl_type`
++replace symbol V4L2_CTRL_TYPE_HEVC_SLICE_PARAMS :c:type:`v4l2_ctrl_type`
+ 
+ # V4L2 capability defines
+ replace define V4L2_CAP_VIDEO_CAPTURE device-capabilities
+diff --git a/drivers/media/v4l2-core/v4l2-ctrls.c b/drivers/media/v4l2-core/v4l2-ctrls.c
+index e25a528f4..67361742c 100644
+--- a/drivers/media/v4l2-core/v4l2-ctrls.c
++++ b/drivers/media/v4l2-core/v4l2-ctrls.c
+@@ -932,6 +932,9 @@ const char *v4l2_ctrl_get_name(u32 id)
+ 	case V4L2_CID_MPEG_VIDEO_HEVC_SIZE_OF_LENGTH_FIELD:	return "HEVC Size of Length Field";
+ 	case V4L2_CID_MPEG_VIDEO_REF_NUMBER_FOR_PFRAMES:	return "Reference Frames for a P-Frame";
+ 	case V4L2_CID_MPEG_VIDEO_PREPEND_SPSPPS_TO_IDR:		return "Prepend SPS and PPS to IDR";
++	case V4L2_CID_MPEG_VIDEO_HEVC_SPS:			return "HEVC Sequence Parameter Set";
++	case V4L2_CID_MPEG_VIDEO_HEVC_PPS:			return "HEVC Picture Parameter Set";
++	case V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS:		return "HEVC Slice Parameters";
+ 
+ 	/* CAMERA controls */
+ 	/* Keep the order of the 'case's the same as in v4l2-controls.h! */
+@@ -1344,6 +1347,15 @@ void v4l2_ctrl_fill(u32 id, const char **name, enum v4l2_ctrl_type *type,
+ 	case V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS:
+ 		*type = V4L2_CTRL_TYPE_H264_DECODE_PARAMS;
+ 		break;
++	case V4L2_CID_MPEG_VIDEO_HEVC_SPS:
++		*type = V4L2_CTRL_TYPE_HEVC_SPS;
++		break;
++	case V4L2_CID_MPEG_VIDEO_HEVC_PPS:
++		*type = V4L2_CTRL_TYPE_HEVC_PPS;
++		break;
++	case V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS:
++		*type = V4L2_CTRL_TYPE_HEVC_SLICE_PARAMS;
++		break;
+ 	default:
+ 		*type = V4L2_CTRL_TYPE_INTEGER;
+ 		break;
+@@ -1720,6 +1732,11 @@ static int std_validate(const struct v4l2_ctrl *ctrl, u32 idx,
+ 	case V4L2_CTRL_TYPE_H264_DECODE_PARAMS:
+ 		return 0;
+ 
++	case V4L2_CTRL_TYPE_HEVC_SPS:
++	case V4L2_CTRL_TYPE_HEVC_PPS:
++	case V4L2_CTRL_TYPE_HEVC_SLICE_PARAMS:
++		return 0;
++
+ 	default:
+ 		return -EINVAL;
+ 	}
+@@ -2318,6 +2335,15 @@ static struct v4l2_ctrl *v4l2_ctrl_new(struct v4l2_ctrl_handler *hdl,
+ 	case V4L2_CTRL_TYPE_H264_DECODE_PARAMS:
+ 		elem_size = sizeof(struct v4l2_ctrl_h264_decode_params);
+ 		break;
++	case V4L2_CTRL_TYPE_HEVC_SPS:
++		elem_size = sizeof(struct v4l2_ctrl_hevc_sps);
++		break;
++	case V4L2_CTRL_TYPE_HEVC_PPS:
++		elem_size = sizeof(struct v4l2_ctrl_hevc_pps);
++		break;
++	case V4L2_CTRL_TYPE_HEVC_SLICE_PARAMS:
++		elem_size = sizeof(struct v4l2_ctrl_hevc_slice_params);
++		break;
+ 	default:
+ 		if (type < V4L2_CTRL_COMPOUND_TYPES)
+ 			elem_size = sizeof(s32);
+diff --git a/drivers/media/v4l2-core/v4l2-ioctl.c b/drivers/media/v4l2-core/v4l2-ioctl.c
+index f9ec2d9ae..9f96893ee 100644
+--- a/drivers/media/v4l2-core/v4l2-ioctl.c
++++ b/drivers/media/v4l2-core/v4l2-ioctl.c
+@@ -1333,6 +1333,7 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
+ 		case V4L2_PIX_FMT_VP8:		descr = "VP8"; break;
+ 		case V4L2_PIX_FMT_VP9:		descr = "VP9"; break;
+ 		case V4L2_PIX_FMT_HEVC:		descr = "HEVC"; break; /* aka H.265 */
++		case V4L2_PIX_FMT_HEVC_SLICE:	descr = "HEVC Parsed Slice Data"; break;
+ 		case V4L2_PIX_FMT_FWHT:		descr = "FWHT"; break; /* used in vicodec */
+ 		case V4L2_PIX_FMT_FWHT_STATELESS:	descr = "FWHT Stateless"; break; /* used in vicodec */
+ 		case V4L2_PIX_FMT_CPIA1:	descr = "GSPCA CPiA YUV"; break;
+diff --git a/drivers/staging/media/sunxi/cedrus/Makefile b/drivers/staging/media/sunxi/cedrus/Makefile
+index c85ac6db0..1bce49d3e 100644
+--- a/drivers/staging/media/sunxi/cedrus/Makefile
++++ b/drivers/staging/media/sunxi/cedrus/Makefile
+@@ -2,4 +2,4 @@
+ obj-$(CONFIG_VIDEO_SUNXI_CEDRUS) += sunxi-cedrus.o
+ 
+ sunxi-cedrus-y = cedrus.o cedrus_video.o cedrus_hw.o cedrus_dec.o \
+-		 cedrus_mpeg2.o cedrus_h264.o
++		 cedrus_mpeg2.o cedrus_h264.o cedrus_h265.o
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus.c b/drivers/staging/media/sunxi/cedrus/cedrus.c
+index 370937edf..70642834f 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus.c
+@@ -70,6 +70,24 @@ static const struct cedrus_control cedrus_controls[] = {
+ 		.codec		= CEDRUS_CODEC_H264,
+ 		.required	= true,
+ 	},
++	{
++		.id		= V4L2_CID_MPEG_VIDEO_HEVC_SPS,
++		.elem_size	= sizeof(struct v4l2_ctrl_hevc_sps),
++		.codec		= CEDRUS_CODEC_H265,
++		.required	= true,
++	},
++	{
++		.id		= V4L2_CID_MPEG_VIDEO_HEVC_PPS,
++		.elem_size	= sizeof(struct v4l2_ctrl_hevc_pps),
++		.codec		= CEDRUS_CODEC_H265,
++		.required	= true,
++	},
++	{
++		.id		= V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS,
++		.elem_size	= sizeof(struct v4l2_ctrl_hevc_slice_params),
++		.codec		= CEDRUS_CODEC_H265,
++		.required	= true,
++	},
+ };
+ 
+ #define CEDRUS_CONTROLS_COUNT	ARRAY_SIZE(cedrus_controls)
+@@ -309,6 +327,7 @@ static int cedrus_probe(struct platform_device *pdev)
+ 
+ 	dev->dec_ops[CEDRUS_CODEC_MPEG2] = &cedrus_dec_ops_mpeg2;
+ 	dev->dec_ops[CEDRUS_CODEC_H264] = &cedrus_dec_ops_h264;
++	dev->dec_ops[CEDRUS_CODEC_H265] = &cedrus_dec_ops_h265;
+ 
+ 	mutex_init(&dev->dev_mutex);
+ 
+@@ -417,22 +436,26 @@ static const struct cedrus_variant sun8i_a33_cedrus_variant = {
+ };
+ 
+ static const struct cedrus_variant sun8i_h3_cedrus_variant = {
+-	.capabilities	= CEDRUS_CAPABILITY_UNTILED,
++	.capabilities	= CEDRUS_CAPABILITY_UNTILED |
++			  CEDRUS_CAPABILITY_H265_DEC,
+ 	.mod_rate	= 402000000,
+ };
+ 
+ static const struct cedrus_variant sun50i_a64_cedrus_variant = {
+-	.capabilities	= CEDRUS_CAPABILITY_UNTILED,
++	.capabilities	= CEDRUS_CAPABILITY_UNTILED |
++			  CEDRUS_CAPABILITY_H265_DEC,
+ 	.mod_rate	= 402000000,
+ };
+ 
+ static const struct cedrus_variant sun50i_h5_cedrus_variant = {
+-	.capabilities	= CEDRUS_CAPABILITY_UNTILED,
++	.capabilities	= CEDRUS_CAPABILITY_UNTILED |
++			  CEDRUS_CAPABILITY_H265_DEC,
+ 	.mod_rate	= 402000000,
+ };
+ 
+ static const struct cedrus_variant sun50i_h6_cedrus_variant = {
+-	.capabilities	= CEDRUS_CAPABILITY_UNTILED,
++	.capabilities	= CEDRUS_CAPABILITY_UNTILED |
++			  CEDRUS_CAPABILITY_H265_DEC,
+ 	.quirks		= CEDRUS_QUIRK_NO_DMA_OFFSET,
+ 	.mod_rate	= 600000000,
+ };
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus.h b/drivers/staging/media/sunxi/cedrus/cedrus.h
+index 3f476d0fd..f19be772d 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus.h
++++ b/drivers/staging/media/sunxi/cedrus/cedrus.h
+@@ -27,12 +27,14 @@
+ #define CEDRUS_NAME			"cedrus"
+ 
+ #define CEDRUS_CAPABILITY_UNTILED	BIT(0)
++#define CEDRUS_CAPABILITY_H265_DEC	BIT(1)
+ 
+ #define CEDRUS_QUIRK_NO_DMA_OFFSET	BIT(0)
+ 
+ enum cedrus_codec {
+ 	CEDRUS_CODEC_MPEG2,
+ 	CEDRUS_CODEC_H264,
++	CEDRUS_CODEC_H265,
+ 	CEDRUS_CODEC_LAST,
+ };
+ 
+@@ -68,6 +70,12 @@ struct cedrus_mpeg2_run {
+ 	const struct v4l2_ctrl_mpeg2_quantization	*quantization;
+ };
+ 
++struct cedrus_h265_run {
++	const struct v4l2_ctrl_hevc_sps			*sps;
++	const struct v4l2_ctrl_hevc_pps			*pps;
++	const struct v4l2_ctrl_hevc_slice_params	*slice_params;
++};
++
+ struct cedrus_run {
+ 	struct vb2_v4l2_buffer	*src;
+ 	struct vb2_v4l2_buffer	*dst;
+@@ -75,6 +83,7 @@ struct cedrus_run {
+ 	union {
+ 		struct cedrus_h264_run	h264;
+ 		struct cedrus_mpeg2_run	mpeg2;
++		struct cedrus_h265_run	h265;
+ 	};
+ };
+ 
+@@ -113,6 +122,14 @@ struct cedrus_ctx {
+ 			void		*neighbor_info_buf;
+ 			dma_addr_t	neighbor_info_buf_dma;
+ 		} h264;
++		struct {
++			void		*mv_col_buf;
++			dma_addr_t	mv_col_buf_addr;
++			ssize_t		mv_col_buf_size;
++			ssize_t		mv_col_buf_unit_size;
++			void		*neighbor_info_buf;
++			dma_addr_t	neighbor_info_buf_addr;
++		} h265;
+ 	} codec;
+ };
+ 
+@@ -158,6 +175,7 @@ struct cedrus_dev {
+ 
+ extern struct cedrus_dec_ops cedrus_dec_ops_mpeg2;
+ extern struct cedrus_dec_ops cedrus_dec_ops_h264;
++extern struct cedrus_dec_ops cedrus_dec_ops_h265;
+ 
+ static inline void cedrus_write(struct cedrus_dev *dev, u32 reg, u32 val)
+ {
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_dec.c b/drivers/staging/media/sunxi/cedrus/cedrus_dec.c
+index bdad87eb9..c6d0ef66c 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_dec.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_dec.c
+@@ -59,6 +59,15 @@ void cedrus_device_run(void *priv)
+ 			V4L2_CID_MPEG_VIDEO_H264_SPS);
+ 		break;
+ 
++	case V4L2_PIX_FMT_HEVC_SLICE:
++		run.h265.sps = cedrus_find_control_data(ctx,
++			V4L2_CID_MPEG_VIDEO_HEVC_SPS);
++		run.h265.pps = cedrus_find_control_data(ctx,
++			V4L2_CID_MPEG_VIDEO_HEVC_PPS);
++		run.h265.slice_params = cedrus_find_control_data(ctx,
++			V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS);
++		break;
++
+ 	default:
+ 		break;
+ 	}
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_h265.c b/drivers/staging/media/sunxi/cedrus/cedrus_h265.c
+new file mode 100644
+index 000000000..fd4d86b02
+--- /dev/null
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_h265.c
+@@ -0,0 +1,532 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Cedrus VPU driver
++ *
++ * Copyright (C) 2013 Jens Kuske <jenskuske@gmail.com>
++ * Copyright (C) 2018 Paul Kocialkowski <paul.kocialkowski@bootlin.com>
++ * Copyright (C) 2018 Bootlin
++ */
++
++#include <linux/types.h>
++
++#include <media/videobuf2-dma-contig.h>
++
++#include "cedrus.h"
++#include "cedrus_hw.h"
++#include "cedrus_regs.h"
++
++/*
++ * These are the sizes for side buffers required by the hardware for storing
++ * internal decoding metadata. They match the values used by the early BSP
++ * implementations, that were initially exposed in libvdpau-sunxi.
++ * Subsequent BSP implementations seem to double the neighbor info buffer size
++ * for the H6 SoC, which may be related to 10 bit H265 support.
++ */
++#define CEDRUS_H265_NEIGHBOR_INFO_BUF_SIZE	(397 * SZ_1K)
++#define CEDRUS_H265_ENTRY_POINTS_BUF_SIZE	(4 * SZ_1K)
++#define CEDRUS_H265_MV_COL_BUF_UNIT_CTB_SIZE	160
++
++struct cedrus_h265_sram_frame_info {
++	__le32	top_pic_order_cnt;
++	__le32	bottom_pic_order_cnt;
++	__le32	top_mv_col_buf_addr;
++	__le32	bottom_mv_col_buf_addr;
++	__le32	luma_addr;
++	__le32	chroma_addr;
++} __packed;
++
++struct cedrus_h265_sram_pred_weight {
++	__s8	delta_weight;
++	__s8	offset;
++} __packed;
++
++static enum cedrus_irq_status cedrus_h265_irq_status(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++	u32 reg;
++
++	reg = cedrus_read(dev, VE_DEC_H265_STATUS);
++	reg &= VE_DEC_H265_STATUS_CHECK_MASK;
++
++	if (reg & VE_DEC_H265_STATUS_CHECK_ERROR ||
++	    !(reg & VE_DEC_H265_STATUS_SUCCESS))
++		return CEDRUS_IRQ_ERROR;
++
++	return CEDRUS_IRQ_OK;
++}
++
++static void cedrus_h265_irq_clear(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++
++	cedrus_write(dev, VE_DEC_H265_STATUS, VE_DEC_H265_STATUS_CHECK_MASK);
++}
++
++static void cedrus_h265_irq_disable(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++	u32 reg = cedrus_read(dev, VE_DEC_H265_CTRL);
++
++	reg &= ~VE_DEC_H265_CTRL_IRQ_MASK;
++
++	cedrus_write(dev, VE_DEC_H265_CTRL, reg);
++}
++
++static void cedrus_h265_sram_write_offset(struct cedrus_dev *dev, u32 offset)
++{
++	cedrus_write(dev, VE_DEC_H265_SRAM_OFFSET, offset);
++}
++
++static void cedrus_h265_sram_write_data(struct cedrus_dev *dev, void *data,
++					unsigned int size)
++{
++	u32 *word = data;
++
++	while (size >= sizeof(u32)) {
++		cedrus_write(dev, VE_DEC_H265_SRAM_DATA, *word++);
++		size -= sizeof(u32);
++	}
++}
++
++static inline dma_addr_t
++cedrus_h265_frame_info_mv_col_buf_addr(struct cedrus_ctx *ctx,
++				       unsigned int index, unsigned int field)
++{
++	return ctx->codec.h265.mv_col_buf_addr + index *
++	       ctx->codec.h265.mv_col_buf_unit_size +
++	       field * ctx->codec.h265.mv_col_buf_unit_size / 2;
++}
++
++static void cedrus_h265_frame_info_write_single(struct cedrus_ctx *ctx,
++						unsigned int index,
++						bool field_pic,
++						u32 pic_order_cnt[],
++						int buffer_index)
++{
++	struct cedrus_dev *dev = ctx->dev;
++	dma_addr_t dst_luma_addr = cedrus_dst_buf_addr(ctx, buffer_index, 0);
++	dma_addr_t dst_chroma_addr = cedrus_dst_buf_addr(ctx, buffer_index, 1);
++	dma_addr_t mv_col_buf_addr[2] = {
++		cedrus_h265_frame_info_mv_col_buf_addr(ctx, buffer_index, 0),
++		cedrus_h265_frame_info_mv_col_buf_addr(ctx, buffer_index,
++						       field_pic ? 1 : 0)
++	};
++	u32 offset = VE_DEC_H265_SRAM_OFFSET_FRAME_INFO +
++		     VE_DEC_H265_SRAM_OFFSET_FRAME_INFO_UNIT * index;
++	struct cedrus_h265_sram_frame_info frame_info = {
++		.top_pic_order_cnt = cpu_to_le32(pic_order_cnt[0]),
++		.bottom_pic_order_cnt = cpu_to_le32(field_pic ?
++						    pic_order_cnt[1] :
++						    pic_order_cnt[0]),
++		.top_mv_col_buf_addr =
++			cpu_to_le32(VE_DEC_H265_SRAM_DATA_ADDR_BASE(mv_col_buf_addr[0])),
++		.bottom_mv_col_buf_addr = cpu_to_le32(field_pic ?
++			VE_DEC_H265_SRAM_DATA_ADDR_BASE(mv_col_buf_addr[1]) :
++			VE_DEC_H265_SRAM_DATA_ADDR_BASE(mv_col_buf_addr[0])),
++		.luma_addr = cpu_to_le32(VE_DEC_H265_SRAM_DATA_ADDR_BASE(dst_luma_addr)),
++		.chroma_addr = cpu_to_le32(VE_DEC_H265_SRAM_DATA_ADDR_BASE(dst_chroma_addr)),
++	};
++
++	cedrus_h265_sram_write_offset(dev, offset);
++	cedrus_h265_sram_write_data(dev, &frame_info, sizeof(frame_info));
++}
++
++static void cedrus_h265_frame_info_write_dpb(struct cedrus_ctx *ctx,
++					     const struct v4l2_hevc_dpb_entry *dpb,
++					     u8 num_active_dpb_entries)
++{
++	struct vb2_queue *vq = v4l2_m2m_get_vq(ctx->fh.m2m_ctx,
++					       V4L2_BUF_TYPE_VIDEO_CAPTURE);
++	unsigned int i;
++
++	for (i = 0; i < num_active_dpb_entries; i++) {
++		int buffer_index = vb2_find_timestamp(vq, dpb[i].timestamp, 0);
++		u32 pic_order_cnt[2] = {
++			dpb[i].pic_order_cnt[0],
++			dpb[i].pic_order_cnt[1]
++		};
++
++		cedrus_h265_frame_info_write_single(ctx, i, dpb[i].field_pic,
++						    pic_order_cnt,
++						    buffer_index);
++	}
++}
++
++static void cedrus_h265_ref_pic_list_write(struct cedrus_dev *dev,
++					   const struct v4l2_hevc_dpb_entry *dpb,
++					   const u8 list[],
++					   u8 num_ref_idx_active,
++					   u32 sram_offset)
++{
++	unsigned int i;
++	u32 word = 0;
++
++	cedrus_h265_sram_write_offset(dev, sram_offset);
++
++	for (i = 0; i < num_ref_idx_active; i++) {
++		unsigned int shift = (i % 4) * 8;
++		unsigned int index = list[i];
++		u8 value = list[i];
++
++		if (dpb[index].rps == V4L2_HEVC_DPB_ENTRY_RPS_LT_CURR)
++			value |= VE_DEC_H265_SRAM_REF_PIC_LIST_LT_REF;
++
++		/* Each SRAM word gathers up to 4 references. */
++		word |= value << shift;
++
++		/* Write the word to SRAM and clear it for the next batch. */
++		if ((i % 4) == 3 || i == (num_ref_idx_active - 1)) {
++			cedrus_h265_sram_write_data(dev, &word, sizeof(word));
++			word = 0;
++		}
++	}
++}
++
++static void cedrus_h265_pred_weight_write(struct cedrus_dev *dev,
++					  const s8 delta_luma_weight[],
++					  const s8 luma_offset[],
++					  const s8 delta_chroma_weight[][2],
++					  const s8 chroma_offset[][2],
++					  u8 num_ref_idx_active,
++					  u32 sram_luma_offset,
++					  u32 sram_chroma_offset)
++{
++	struct cedrus_h265_sram_pred_weight pred_weight[2] = { { 0 } };
++	unsigned int i, j;
++
++	cedrus_h265_sram_write_offset(dev, sram_luma_offset);
++
++	for (i = 0; i < num_ref_idx_active; i++) {
++		unsigned int index = i % 2;
++
++		pred_weight[index].delta_weight = delta_luma_weight[i];
++		pred_weight[index].offset = luma_offset[i];
++
++		if (index == 1 || i == (num_ref_idx_active - 1))
++			cedrus_h265_sram_write_data(dev, (u32 *)&pred_weight,
++						    sizeof(pred_weight));
++	}
++
++	cedrus_h265_sram_write_offset(dev, sram_chroma_offset);
++
++	for (i = 0; i < num_ref_idx_active; i++) {
++		for (j = 0; j < 2; j++) {
++			pred_weight[j].delta_weight = delta_chroma_weight[i][j];
++			pred_weight[j].offset = chroma_offset[i][j];
++		}
++
++		cedrus_h265_sram_write_data(dev, &pred_weight,
++					    sizeof(pred_weight));
++	}
++}
++
++static void cedrus_h265_setup(struct cedrus_ctx *ctx,
++			      struct cedrus_run *run)
++{
++	struct cedrus_dev *dev = ctx->dev;
++	const struct v4l2_ctrl_hevc_sps *sps;
++	const struct v4l2_ctrl_hevc_pps *pps;
++	const struct v4l2_ctrl_hevc_slice_params *slice_params;
++	const struct v4l2_hevc_pred_weight_table *pred_weight_table;
++	dma_addr_t src_buf_addr;
++	dma_addr_t src_buf_end_addr;
++	u32 chroma_log2_weight_denom;
++	u32 output_pic_list_index;
++	u32 pic_order_cnt[2];
++	u32 reg;
++
++	sps = run->h265.sps;
++	pps = run->h265.pps;
++	slice_params = run->h265.slice_params;
++	pred_weight_table = &slice_params->pred_weight_table;
++
++	/* MV column buffer size and allocation. */
++	if (!ctx->codec.h265.mv_col_buf_size) {
++		unsigned int num_buffers =
++			run->dst->vb2_buf.vb2_queue->num_buffers;
++		unsigned int log2_max_luma_coding_block_size =
++			sps->log2_min_luma_coding_block_size_minus3 + 3 +
++			sps->log2_diff_max_min_luma_coding_block_size;
++		unsigned int ctb_size_luma =
++			1 << log2_max_luma_coding_block_size;
++
++		/*
++		 * Each CTB requires a MV col buffer with a specific unit size.
++		 * Since the address is given with missing lsb bits, 1 KiB is
++		 * added to each buffer to ensure proper alignment.
++		 */
++		ctx->codec.h265.mv_col_buf_unit_size =
++			DIV_ROUND_UP(ctx->src_fmt.width, ctb_size_luma) *
++			DIV_ROUND_UP(ctx->src_fmt.height, ctb_size_luma) *
++			CEDRUS_H265_MV_COL_BUF_UNIT_CTB_SIZE + SZ_1K;
++
++		ctx->codec.h265.mv_col_buf_size = num_buffers *
++			ctx->codec.h265.mv_col_buf_unit_size;
++
++		ctx->codec.h265.mv_col_buf =
++			dma_alloc_coherent(dev->dev,
++					   ctx->codec.h265.mv_col_buf_size,
++					   &ctx->codec.h265.mv_col_buf_addr,
++					   GFP_KERNEL);
++		if (!ctx->codec.h265.mv_col_buf) {
++			ctx->codec.h265.mv_col_buf_size = 0;
++			// TODO: Abort the process here.
++			return;
++		}
++	}
++
++	/* Activate H265 engine. */
++	cedrus_engine_enable(dev, CEDRUS_CODEC_H265);
++
++	/* Source offset and length in bits. */
++
++	reg = slice_params->data_bit_offset;
++	cedrus_write(dev, VE_DEC_H265_BITS_OFFSET, reg);
++
++	reg = slice_params->bit_size - slice_params->data_bit_offset;
++	cedrus_write(dev, VE_DEC_H265_BITS_LEN, reg);
++
++	/* Source beginning and end addresses. */
++
++	src_buf_addr = vb2_dma_contig_plane_dma_addr(&run->src->vb2_buf, 0);
++
++	reg = VE_DEC_H265_BITS_ADDR_BASE(src_buf_addr);
++	reg |= VE_DEC_H265_BITS_ADDR_VALID_SLICE_DATA;
++	reg |= VE_DEC_H265_BITS_ADDR_LAST_SLICE_DATA;
++	reg |= VE_DEC_H265_BITS_ADDR_FIRST_SLICE_DATA;
++
++	cedrus_write(dev, VE_DEC_H265_BITS_ADDR, reg);
++
++	src_buf_end_addr = src_buf_addr +
++			   DIV_ROUND_UP(slice_params->bit_size, 8);
++
++	reg = VE_DEC_H265_BITS_END_ADDR_BASE(src_buf_end_addr);
++	cedrus_write(dev, VE_DEC_H265_BITS_END_ADDR, reg);
++
++	/* Coding tree block address: start at the beginning. */
++	reg = VE_DEC_H265_DEC_CTB_ADDR_X(0) | VE_DEC_H265_DEC_CTB_ADDR_Y(0);
++	cedrus_write(dev, VE_DEC_H265_DEC_CTB_ADDR, reg);
++
++	cedrus_write(dev, VE_DEC_H265_TILE_START_CTB, 0);
++	cedrus_write(dev, VE_DEC_H265_TILE_END_CTB, 0);
++
++	/* Clear the number of correctly-decoded coding tree blocks. */
++	cedrus_write(dev, VE_DEC_H265_DEC_CTB_NUM, 0);
++
++	/* Initialize bitstream access. */
++	cedrus_write(dev, VE_DEC_H265_TRIGGER, VE_DEC_H265_TRIGGER_INIT_SWDEC);
++
++	/* Bitstream parameters. */
++
++	reg = VE_DEC_H265_DEC_NAL_HDR_NAL_UNIT_TYPE(slice_params->nal_unit_type) |
++	      VE_DEC_H265_DEC_NAL_HDR_NUH_TEMPORAL_ID_PLUS1(slice_params->nuh_temporal_id_plus1);
++
++	cedrus_write(dev, VE_DEC_H265_DEC_NAL_HDR, reg);
++
++	reg = VE_DEC_H265_DEC_SPS_HDR_STRONG_INTRA_SMOOTHING_ENABLE_FLAG(sps->strong_intra_smoothing_enabled_flag) |
++	      VE_DEC_H265_DEC_SPS_HDR_SPS_TEMPORAL_MVP_ENABLED_FLAG(sps->sps_temporal_mvp_enabled_flag) |
++	      VE_DEC_H265_DEC_SPS_HDR_SAMPLE_ADAPTIVE_OFFSET_ENABLED_FLAG(sps->sample_adaptive_offset_enabled_flag) |
++	      VE_DEC_H265_DEC_SPS_HDR_AMP_ENABLED_FLAG(sps->amp_enabled_flag) |
++	      VE_DEC_H265_DEC_SPS_HDR_MAX_TRANSFORM_HIERARCHY_DEPTH_INTRA(sps->max_transform_hierarchy_depth_intra) |
++	      VE_DEC_H265_DEC_SPS_HDR_MAX_TRANSFORM_HIERARCHY_DEPTH_INTER(sps->max_transform_hierarchy_depth_inter) |
++	      VE_DEC_H265_DEC_SPS_HDR_LOG2_DIFF_MAX_MIN_TRANSFORM_BLOCK_SIZE(sps->log2_diff_max_min_luma_transform_block_size) |
++	      VE_DEC_H265_DEC_SPS_HDR_LOG2_MIN_TRANSFORM_BLOCK_SIZE_MINUS2(sps->log2_min_luma_transform_block_size_minus2) |
++	      VE_DEC_H265_DEC_SPS_HDR_LOG2_DIFF_MAX_MIN_LUMA_CODING_BLOCK_SIZE(sps->log2_diff_max_min_luma_coding_block_size) |
++	      VE_DEC_H265_DEC_SPS_HDR_LOG2_MIN_LUMA_CODING_BLOCK_SIZE_MINUS3(sps->log2_min_luma_coding_block_size_minus3) |
++	      VE_DEC_H265_DEC_SPS_HDR_BIT_DEPTH_CHROMA_MINUS8(sps->bit_depth_chroma_minus8) |
++	      VE_DEC_H265_DEC_SPS_HDR_SEPARATE_COLOUR_PLANE_FLAG(sps->separate_colour_plane_flag) |
++	      VE_DEC_H265_DEC_SPS_HDR_CHROMA_FORMAT_IDC(sps->chroma_format_idc);
++
++	cedrus_write(dev, VE_DEC_H265_DEC_SPS_HDR, reg);
++
++	reg = VE_DEC_H265_DEC_PCM_CTRL_PCM_ENABLED_FLAG(sps->pcm_enabled_flag) |
++	      VE_DEC_H265_DEC_PCM_CTRL_PCM_LOOP_FILTER_DISABLED_FLAG(sps->pcm_loop_filter_disabled_flag) |
++	      VE_DEC_H265_DEC_PCM_CTRL_LOG2_DIFF_MAX_MIN_PCM_LUMA_CODING_BLOCK_SIZE(sps->log2_diff_max_min_pcm_luma_coding_block_size) |
++	      VE_DEC_H265_DEC_PCM_CTRL_LOG2_MIN_PCM_LUMA_CODING_BLOCK_SIZE_MINUS3(sps->log2_min_pcm_luma_coding_block_size_minus3) |
++	      VE_DEC_H265_DEC_PCM_CTRL_PCM_SAMPLE_BIT_DEPTH_CHROMA_MINUS1(sps->pcm_sample_bit_depth_chroma_minus1) |
++	      VE_DEC_H265_DEC_PCM_CTRL_PCM_SAMPLE_BIT_DEPTH_LUMA_MINUS1(sps->pcm_sample_bit_depth_luma_minus1);
++
++	cedrus_write(dev, VE_DEC_H265_DEC_PCM_CTRL, reg);
++
++	reg = VE_DEC_H265_DEC_PPS_CTRL0_PPS_CR_QP_OFFSET(pps->pps_cr_qp_offset) |
++	      VE_DEC_H265_DEC_PPS_CTRL0_PPS_CB_QP_OFFSET(pps->pps_cb_qp_offset) |
++	      VE_DEC_H265_DEC_PPS_CTRL0_INIT_QP_MINUS26(pps->init_qp_minus26) |
++	      VE_DEC_H265_DEC_PPS_CTRL0_DIFF_CU_QP_DELTA_DEPTH(pps->diff_cu_qp_delta_depth) |
++	      VE_DEC_H265_DEC_PPS_CTRL0_CU_QP_DELTA_ENABLED_FLAG(pps->cu_qp_delta_enabled_flag) |
++	      VE_DEC_H265_DEC_PPS_CTRL0_TRANSFORM_SKIP_ENABLED_FLAG(pps->transform_skip_enabled_flag) |
++	      VE_DEC_H265_DEC_PPS_CTRL0_CONSTRAINED_INTRA_PRED_FLAG(pps->constrained_intra_pred_flag) |
++	      VE_DEC_H265_DEC_PPS_CTRL0_SIGN_DATA_HIDING_FLAG(pps->sign_data_hiding_enabled_flag);
++
++	cedrus_write(dev, VE_DEC_H265_DEC_PPS_CTRL0, reg);
++
++	reg = VE_DEC_H265_DEC_PPS_CTRL1_LOG2_PARALLEL_MERGE_LEVEL_MINUS2(pps->log2_parallel_merge_level_minus2) |
++	      VE_DEC_H265_DEC_PPS_CTRL1_PPS_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG(pps->pps_loop_filter_across_slices_enabled_flag) |
++	      VE_DEC_H265_DEC_PPS_CTRL1_LOOP_FILTER_ACROSS_TILES_ENABLED_FLAG(pps->loop_filter_across_tiles_enabled_flag) |
++	      VE_DEC_H265_DEC_PPS_CTRL1_ENTROPY_CODING_SYNC_ENABLED_FLAG(pps->entropy_coding_sync_enabled_flag) |
++	      VE_DEC_H265_DEC_PPS_CTRL1_TILES_ENABLED_FLAG(0) |
++	      VE_DEC_H265_DEC_PPS_CTRL1_TRANSQUANT_BYPASS_ENABLE_FLAG(pps->transquant_bypass_enabled_flag) |
++	      VE_DEC_H265_DEC_PPS_CTRL1_WEIGHTED_BIPRED_FLAG(pps->weighted_bipred_flag) |
++	      VE_DEC_H265_DEC_PPS_CTRL1_WEIGHTED_PRED_FLAG(pps->weighted_pred_flag);
++
++	cedrus_write(dev, VE_DEC_H265_DEC_PPS_CTRL1, reg);
++
++	reg = VE_DEC_H265_DEC_SLICE_HDR_INFO0_PICTURE_TYPE(slice_params->pic_struct) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_FIVE_MINUS_MAX_NUM_MERGE_CAND(slice_params->five_minus_max_num_merge_cand) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_NUM_REF_IDX_L1_ACTIVE_MINUS1(slice_params->num_ref_idx_l1_active_minus1) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_NUM_REF_IDX_L0_ACTIVE_MINUS1(slice_params->num_ref_idx_l0_active_minus1) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_COLLOCATED_REF_IDX(slice_params->collocated_ref_idx) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_COLLOCATED_FROM_L0_FLAG(slice_params->collocated_from_l0_flag) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_CABAC_INIT_FLAG(slice_params->cabac_init_flag) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_MVD_L1_ZERO_FLAG(slice_params->mvd_l1_zero_flag) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_SLICE_SAO_CHROMA_FLAG(slice_params->slice_sao_chroma_flag) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_SLICE_SAO_LUMA_FLAG(slice_params->slice_sao_luma_flag) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_SLICE_TEMPORAL_MVP_ENABLE_FLAG(slice_params->slice_temporal_mvp_enabled_flag) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_COLOUR_PLANE_ID(slice_params->colour_plane_id) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_SLICE_TYPE(slice_params->slice_type) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_DEPENDENT_SLICE_SEGMENT_FLAG(pps->dependent_slice_segment_flag) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_FIRST_SLICE_SEGMENT_IN_PIC_FLAG(1);
++
++	cedrus_write(dev, VE_DEC_H265_DEC_SLICE_HDR_INFO0, reg);
++
++	reg = VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_TC_OFFSET_DIV2(slice_params->slice_tc_offset_div2) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_BETA_OFFSET_DIV2(slice_params->slice_beta_offset_div2) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_DEBLOCKING_FILTER_DISABLED_FLAG(slice_params->slice_deblocking_filter_disabled_flag) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG(slice_params->slice_loop_filter_across_slices_enabled_flag) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_POC_BIGEST_IN_RPS_ST(slice_params->num_rps_poc_st_curr_after == 0) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_CR_QP_OFFSET(slice_params->slice_cr_qp_offset) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_CB_QP_OFFSET(slice_params->slice_cb_qp_offset) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_QP_DELTA(slice_params->slice_qp_delta);
++
++	cedrus_write(dev, VE_DEC_H265_DEC_SLICE_HDR_INFO1, reg);
++
++	chroma_log2_weight_denom = pred_weight_table->luma_log2_weight_denom +
++				   pred_weight_table->delta_chroma_log2_weight_denom;
++	reg = VE_DEC_H265_DEC_SLICE_HDR_INFO2_NUM_ENTRY_POINT_OFFSETS(0) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO2_CHROMA_LOG2_WEIGHT_DENOM(chroma_log2_weight_denom) |
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO2_LUMA_LOG2_WEIGHT_DENOM(pred_weight_table->luma_log2_weight_denom);
++
++	cedrus_write(dev, VE_DEC_H265_DEC_SLICE_HDR_INFO2, reg);
++
++	/* Decoded picture size. */
++
++	reg = VE_DEC_H265_DEC_PIC_SIZE_WIDTH(ctx->src_fmt.width) |
++	      VE_DEC_H265_DEC_PIC_SIZE_HEIGHT(ctx->src_fmt.height);
++
++	cedrus_write(dev, VE_DEC_H265_DEC_PIC_SIZE, reg);
++
++	/* Scaling list. */
++
++	reg = VE_DEC_H265_SCALING_LIST_CTRL0_DEFAULT;
++	cedrus_write(dev, VE_DEC_H265_SCALING_LIST_CTRL0, reg);
++
++	/* Neightbor information address. */
++	reg = VE_DEC_H265_NEIGHBOR_INFO_ADDR_BASE(ctx->codec.h265.neighbor_info_buf_addr);
++	cedrus_write(dev, VE_DEC_H265_NEIGHBOR_INFO_ADDR, reg);
++
++	/* Write decoded picture buffer in pic list. */
++	cedrus_h265_frame_info_write_dpb(ctx, slice_params->dpb,
++					 slice_params->num_active_dpb_entries);
++
++	/* Output frame. */
++
++	output_pic_list_index = V4L2_HEVC_DPB_ENTRIES_NUM_MAX;
++	pic_order_cnt[0] = slice_params->slice_pic_order_cnt;
++	pic_order_cnt[1] = slice_params->slice_pic_order_cnt;
++
++	cedrus_h265_frame_info_write_single(ctx, output_pic_list_index,
++					    slice_params->pic_struct != 0,
++					    pic_order_cnt,
++					    run->dst->vb2_buf.index);
++
++	cedrus_write(dev, VE_DEC_H265_OUTPUT_FRAME_IDX, output_pic_list_index);
++
++	/* Reference picture list 0 (for P/B frames). */
++	if (slice_params->slice_type != V4L2_HEVC_SLICE_TYPE_I) {
++		cedrus_h265_ref_pic_list_write(dev, slice_params->dpb,
++					       slice_params->ref_idx_l0,
++					       slice_params->num_ref_idx_l0_active_minus1 + 1,
++					       VE_DEC_H265_SRAM_OFFSET_REF_PIC_LIST0);
++
++		if (pps->weighted_pred_flag || pps->weighted_bipred_flag)
++			cedrus_h265_pred_weight_write(dev,
++						      pred_weight_table->delta_luma_weight_l0,
++						      pred_weight_table->luma_offset_l0,
++						      pred_weight_table->delta_chroma_weight_l0,
++						      pred_weight_table->chroma_offset_l0,
++						      slice_params->num_ref_idx_l0_active_minus1 + 1,
++						      VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_LUMA_L0,
++						      VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_CHROMA_L0);
++	}
++
++	/* Reference picture list 1 (for B frames). */
++	if (slice_params->slice_type == V4L2_HEVC_SLICE_TYPE_B) {
++		cedrus_h265_ref_pic_list_write(dev, slice_params->dpb,
++					       slice_params->ref_idx_l1,
++					       slice_params->num_ref_idx_l1_active_minus1 + 1,
++					       VE_DEC_H265_SRAM_OFFSET_REF_PIC_LIST1);
++
++		if (pps->weighted_bipred_flag)
++			cedrus_h265_pred_weight_write(dev,
++						      pred_weight_table->delta_luma_weight_l1,
++						      pred_weight_table->luma_offset_l1,
++						      pred_weight_table->delta_chroma_weight_l1,
++						      pred_weight_table->chroma_offset_l1,
++						      slice_params->num_ref_idx_l1_active_minus1 + 1,
++						      VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_LUMA_L1,
++						      VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_CHROMA_L1);
++	}
++
++	/* Enable appropriate interruptions. */
++	cedrus_write(dev, VE_DEC_H265_CTRL, VE_DEC_H265_CTRL_IRQ_MASK);
++}
++
++static int cedrus_h265_start(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++
++	/* The buffer size is calculated at setup time. */
++	ctx->codec.h265.mv_col_buf_size = 0;
++
++	ctx->codec.h265.neighbor_info_buf =
++		dma_alloc_coherent(dev->dev, CEDRUS_H265_NEIGHBOR_INFO_BUF_SIZE,
++				   &ctx->codec.h265.neighbor_info_buf_addr,
++				   GFP_KERNEL);
++	if (!ctx->codec.h265.neighbor_info_buf)
++		return -ENOMEM;
++
++	return 0;
++}
++
++static void cedrus_h265_stop(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++
++	if (ctx->codec.h265.mv_col_buf_size > 0) {
++		dma_free_coherent(dev->dev, ctx->codec.h265.mv_col_buf_size,
++				  ctx->codec.h265.mv_col_buf,
++				  ctx->codec.h265.mv_col_buf_addr);
++
++		ctx->codec.h265.mv_col_buf_size = 0;
++	}
++
++	dma_free_coherent(dev->dev, CEDRUS_H265_NEIGHBOR_INFO_BUF_SIZE,
++			  ctx->codec.h265.neighbor_info_buf,
++			  ctx->codec.h265.neighbor_info_buf_addr);
++}
++
++static void cedrus_h265_trigger(struct cedrus_ctx *ctx)
++{
++	struct cedrus_dev *dev = ctx->dev;
++
++	cedrus_write(dev, VE_DEC_H265_TRIGGER, VE_DEC_H265_TRIGGER_DEC_SLICE);
++}
++
++struct cedrus_dec_ops cedrus_dec_ops_h265 = {
++	.irq_clear	= cedrus_h265_irq_clear,
++	.irq_disable	= cedrus_h265_irq_disable,
++	.irq_status	= cedrus_h265_irq_status,
++	.setup		= cedrus_h265_setup,
++	.start		= cedrus_h265_start,
++	.stop		= cedrus_h265_stop,
++	.trigger	= cedrus_h265_trigger,
++};
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_hw.c b/drivers/staging/media/sunxi/cedrus/cedrus_hw.c
+index c34aec7c6..7d2f6eedf 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_hw.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_hw.c
+@@ -50,6 +50,10 @@ int cedrus_engine_enable(struct cedrus_dev *dev, enum cedrus_codec codec)
+ 		reg |= VE_MODE_DEC_H264;
+ 		break;
+ 
++	case CEDRUS_CODEC_H265:
++		reg |= VE_MODE_DEC_H265;
++		break;
++
+ 	default:
+ 		return -EINVAL;
+ 	}
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_regs.h b/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
+index 3e9931416..87651d6b6 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
+@@ -18,10 +18,17 @@
+  * * MC: Motion Compensation
+  * * STCD: Start Code Detect
+  * * SDRT: Scale Down and Rotate
++ * * WB: Writeback
++ * * BITS/BS: Bitstream
++ * * MB: Macroblock
++ * * CTU: Coding Tree Unit
++ * * CTB: Coding Tree Block
++ * * IDX: Index
+  */
+ 
+ #define VE_ENGINE_DEC_MPEG			0x100
+ #define VE_ENGINE_DEC_H264			0x200
++#define VE_ENGINE_DEC_H265			0x500
+ 
+ #define VE_MODE					0x00
+ 
+@@ -232,6 +239,289 @@
+ #define VE_DEC_MPEG_ROT_LUMA			(VE_ENGINE_DEC_MPEG + 0xcc)
+ #define VE_DEC_MPEG_ROT_CHROMA			(VE_ENGINE_DEC_MPEG + 0xd0)
+ 
++#define VE_DEC_H265_DEC_NAL_HDR			(VE_ENGINE_DEC_H265 + 0x00)
++
++#define VE_DEC_H265_DEC_NAL_HDR_NUH_TEMPORAL_ID_PLUS1(v) \
++	(((v) << 6) & GENMASK(8, 6))
++#define VE_DEC_H265_DEC_NAL_HDR_NAL_UNIT_TYPE(v) \
++	((v) & GENMASK(5, 0))
++
++#define VE_DEC_H265_DEC_SPS_HDR			(VE_ENGINE_DEC_H265 + 0x04)
++
++#define VE_DEC_H265_DEC_SPS_HDR_STRONG_INTRA_SMOOTHING_ENABLE_FLAG(v) \
++	((v) ? BIT(26) : 0)
++#define VE_DEC_H265_DEC_SPS_HDR_SPS_TEMPORAL_MVP_ENABLED_FLAG(v) \
++	((v) ? BIT(25) : 0)
++#define VE_DEC_H265_DEC_SPS_HDR_SAMPLE_ADAPTIVE_OFFSET_ENABLED_FLAG(v) \
++	((v) ? BIT(24) : 0)
++#define VE_DEC_H265_DEC_SPS_HDR_AMP_ENABLED_FLAG(v) \
++	((v) ? BIT(23) : 0)
++#define VE_DEC_H265_DEC_SPS_HDR_MAX_TRANSFORM_HIERARCHY_DEPTH_INTRA(v) \
++	(((v) << 20) & GENMASK(22, 20))
++#define VE_DEC_H265_DEC_SPS_HDR_MAX_TRANSFORM_HIERARCHY_DEPTH_INTER(v) \
++	(((v) << 17) & GENMASK(19, 17))
++#define VE_DEC_H265_DEC_SPS_HDR_LOG2_DIFF_MAX_MIN_TRANSFORM_BLOCK_SIZE(v) \
++	(((v) << 15) & GENMASK(16, 15))
++#define VE_DEC_H265_DEC_SPS_HDR_LOG2_MIN_TRANSFORM_BLOCK_SIZE_MINUS2(v) \
++	(((v) << 13) & GENMASK(14, 13))
++#define VE_DEC_H265_DEC_SPS_HDR_LOG2_DIFF_MAX_MIN_LUMA_CODING_BLOCK_SIZE(v) \
++	(((v) << 11) & GENMASK(12, 11))
++#define VE_DEC_H265_DEC_SPS_HDR_LOG2_MIN_LUMA_CODING_BLOCK_SIZE_MINUS3(v) \
++	(((v) << 9) & GENMASK(10, 9))
++#define VE_DEC_H265_DEC_SPS_HDR_BIT_DEPTH_CHROMA_MINUS8(v) \
++	(((v) << 6) & GENMASK(8, 6))
++#define VE_DEC_H265_DEC_SPS_HDR_BIT_DEPTH_LUMA_MINUS8(v) \
++	(((v) << 3) & GENMASK(5, 3))
++#define VE_DEC_H265_DEC_SPS_HDR_SEPARATE_COLOUR_PLANE_FLAG(v) \
++	((v) ? BIT(2) : 0)
++#define VE_DEC_H265_DEC_SPS_HDR_CHROMA_FORMAT_IDC(v) \
++	((v) & GENMASK(1, 0))
++
++#define VE_DEC_H265_DEC_PIC_SIZE		(VE_ENGINE_DEC_H265 + 0x08)
++
++#define VE_DEC_H265_DEC_PIC_SIZE_WIDTH(w)	(((w) << 0) & GENMASK(13, 0))
++#define VE_DEC_H265_DEC_PIC_SIZE_HEIGHT(h)	(((h) << 16) & GENMASK(29, 16))
++
++#define VE_DEC_H265_DEC_PCM_CTRL		(VE_ENGINE_DEC_H265 + 0x0c)
++
++#define VE_DEC_H265_DEC_PCM_CTRL_PCM_ENABLED_FLAG(v) \
++	((v) ? BIT(15) : 0)
++#define VE_DEC_H265_DEC_PCM_CTRL_PCM_LOOP_FILTER_DISABLED_FLAG(v) \
++	((v) ? BIT(14) : 0)
++#define VE_DEC_H265_DEC_PCM_CTRL_LOG2_DIFF_MAX_MIN_PCM_LUMA_CODING_BLOCK_SIZE(v) \
++	(((v) << 10) & GENMASK(11, 10))
++#define VE_DEC_H265_DEC_PCM_CTRL_LOG2_MIN_PCM_LUMA_CODING_BLOCK_SIZE_MINUS3(v) \
++	(((v) << 8) & GENMASK(9, 8))
++#define VE_DEC_H265_DEC_PCM_CTRL_PCM_SAMPLE_BIT_DEPTH_CHROMA_MINUS1(v) \
++	(((v) << 4) & GENMASK(7, 4))
++#define VE_DEC_H265_DEC_PCM_CTRL_PCM_SAMPLE_BIT_DEPTH_LUMA_MINUS1(v) \
++	(((v) << 0) & GENMASK(3, 0))
++
++#define VE_DEC_H265_DEC_PPS_CTRL0		(VE_ENGINE_DEC_H265 + 0x10)
++
++#define VE_DEC_H265_DEC_PPS_CTRL0_PPS_CR_QP_OFFSET(v) \
++	(((v) << 24) & GENMASK(29, 24))
++#define VE_DEC_H265_DEC_PPS_CTRL0_PPS_CB_QP_OFFSET(v) \
++	(((v) << 16) & GENMASK(21, 16))
++#define VE_DEC_H265_DEC_PPS_CTRL0_INIT_QP_MINUS26(v) \
++	(((v) << 8) & GENMASK(14, 8))
++#define VE_DEC_H265_DEC_PPS_CTRL0_DIFF_CU_QP_DELTA_DEPTH(v) \
++	(((v) << 4) & GENMASK(5, 4))
++#define VE_DEC_H265_DEC_PPS_CTRL0_CU_QP_DELTA_ENABLED_FLAG(v) \
++	((v) ? BIT(3) : 0)
++#define VE_DEC_H265_DEC_PPS_CTRL0_TRANSFORM_SKIP_ENABLED_FLAG(v) \
++	((v) ? BIT(2) : 0)
++#define VE_DEC_H265_DEC_PPS_CTRL0_CONSTRAINED_INTRA_PRED_FLAG(v) \
++	((v) ? BIT(1) : 0)
++#define VE_DEC_H265_DEC_PPS_CTRL0_SIGN_DATA_HIDING_FLAG(v) \
++	((v) ? BIT(0) : 0)
++
++#define VE_DEC_H265_DEC_PPS_CTRL1		(VE_ENGINE_DEC_H265 + 0x14)
++
++#define VE_DEC_H265_DEC_PPS_CTRL1_LOG2_PARALLEL_MERGE_LEVEL_MINUS2(v) \
++	(((v) << 8) & GENMASK(10, 8))
++#define VE_DEC_H265_DEC_PPS_CTRL1_PPS_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG(v) \
++	((v) ? BIT(6) : 0)
++#define VE_DEC_H265_DEC_PPS_CTRL1_LOOP_FILTER_ACROSS_TILES_ENABLED_FLAG(v) \
++	((v) ? BIT(5) : 0)
++#define VE_DEC_H265_DEC_PPS_CTRL1_ENTROPY_CODING_SYNC_ENABLED_FLAG(v) \
++	((v) ? BIT(4) : 0)
++#define VE_DEC_H265_DEC_PPS_CTRL1_TILES_ENABLED_FLAG(v) \
++	((v) ? BIT(3) : 0)
++#define VE_DEC_H265_DEC_PPS_CTRL1_TRANSQUANT_BYPASS_ENABLE_FLAG(v) \
++	((v) ? BIT(2) : 0)
++#define VE_DEC_H265_DEC_PPS_CTRL1_WEIGHTED_BIPRED_FLAG(v) \
++	((v) ? BIT(1) : 0)
++#define VE_DEC_H265_DEC_PPS_CTRL1_WEIGHTED_PRED_FLAG(v) \
++	((v) ? BIT(0) : 0)
++
++#define VE_DEC_H265_SCALING_LIST_CTRL0		(VE_ENGINE_DEC_H265 + 0x18)
++
++#define VE_DEC_H265_SCALING_LIST_CTRL0_ENABLED_FLAG(v) \
++	((v) ? BIT(31) : 0)
++#define VE_DEC_H265_SCALING_LIST_CTRL0_SRAM	(0 << 30)
++#define VE_DEC_H265_SCALING_LIST_CTRL0_DEFAULT	(1 << 30)
++
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0		(VE_ENGINE_DEC_H265 + 0x20)
++
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_PICTURE_TYPE(v) \
++	(((v) << 28) & GENMASK(29, 28))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_FIVE_MINUS_MAX_NUM_MERGE_CAND(v) \
++	(((v) << 24) & GENMASK(26, 24))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_NUM_REF_IDX_L1_ACTIVE_MINUS1(v) \
++	(((v) << 20) & GENMASK(23, 20))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_NUM_REF_IDX_L0_ACTIVE_MINUS1(v) \
++	(((v) << 16) & GENMASK(19, 16))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_COLLOCATED_REF_IDX(v) \
++	(((v) << 12) & GENMASK(15, 12))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_COLLOCATED_FROM_L0_FLAG(v) \
++	((v) ? BIT(11) : 0)
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_CABAC_INIT_FLAG(v) \
++	((v) ? BIT(10) : 0)
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_MVD_L1_ZERO_FLAG(v) \
++	((v) ? BIT(9) : 0)
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_SLICE_SAO_CHROMA_FLAG(v) \
++	((v) ? BIT(8) : 0)
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_SLICE_SAO_LUMA_FLAG(v) \
++	((v) ? BIT(7) : 0)
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_SLICE_TEMPORAL_MVP_ENABLE_FLAG(v) \
++	((v) ? BIT(6) : 0)
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_COLOUR_PLANE_ID(v) \
++	(((v) << 4) & GENMASK(5, 4))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_SLICE_TYPE(v) \
++	(((v) << 2) & GENMASK(3, 2))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_DEPENDENT_SLICE_SEGMENT_FLAG(v) \
++	((v) ? BIT(1) : 0)
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO0_FIRST_SLICE_SEGMENT_IN_PIC_FLAG(v) \
++	((v) ? BIT(0) : 0)
++
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO1		(VE_ENGINE_DEC_H265 + 0x24)
++
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_TC_OFFSET_DIV2(v) \
++	(((v) << 28) & GENMASK(31, 28))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_BETA_OFFSET_DIV2(v) \
++	(((v) << 24) & GENMASK(27, 24))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_DEBLOCKING_FILTER_DISABLED_FLAG(v) \
++	((v) ? BIT(23) : 0)
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG(v) \
++	((v) ? BIT(22) : 0)
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_POC_BIGEST_IN_RPS_ST(v) \
++	((v) ? BIT(21) : 0)
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_CR_QP_OFFSET(v) \
++	(((v) << 16) & GENMASK(20, 16))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_CB_QP_OFFSET(v) \
++	(((v) << 8) & GENMASK(12, 8))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO1_SLICE_QP_DELTA(v) \
++	((v) & GENMASK(6, 0))
++
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO2		(VE_ENGINE_DEC_H265 + 0x28)
++
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO2_NUM_ENTRY_POINT_OFFSETS(v) \
++	(((v) << 8) & GENMASK(21, 8))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO2_CHROMA_LOG2_WEIGHT_DENOM(v) \
++	(((v) << 4) & GENMASK(6, 4))
++#define VE_DEC_H265_DEC_SLICE_HDR_INFO2_LUMA_LOG2_WEIGHT_DENOM(v) \
++	(((v) << 0) & GENMASK(2, 0))
++
++#define VE_DEC_H265_DEC_CTB_ADDR		(VE_ENGINE_DEC_H265 + 0x2c)
++
++#define VE_DEC_H265_DEC_CTB_ADDR_Y(y)		(((y) << 16) & GENMASK(25, 16))
++#define VE_DEC_H265_DEC_CTB_ADDR_X(x)		(((x) << 0) & GENMASK(9, 0))
++
++#define VE_DEC_H265_CTRL			(VE_ENGINE_DEC_H265 + 0x30)
++
++#define VE_DEC_H265_CTRL_DDR_CONSISTENCY_EN	BIT(31)
++#define VE_DEC_H265_CTRL_STCD_EN		BIT(25)
++#define VE_DEC_H265_CTRL_EPTB_DEC_BYPASS_EN	BIT(24)
++#define VE_DEC_H265_CTRL_TQ_BYPASS_EN		BIT(12)
++#define VE_DEC_H265_CTRL_VLD_BYPASS_EN		BIT(11)
++#define VE_DEC_H265_CTRL_NCRI_CACHE_DISABLE	BIT(10)
++#define VE_DEC_H265_CTRL_ROTATE_SCALE_OUT_EN	BIT(9)
++#define VE_DEC_H265_CTRL_MC_NO_WRITEBACK	BIT(8)
++#define VE_DEC_H265_CTRL_VLD_DATA_REQ_IRQ_EN	BIT(2)
++#define VE_DEC_H265_CTRL_ERROR_IRQ_EN		BIT(1)
++#define VE_DEC_H265_CTRL_FINISH_IRQ_EN		BIT(0)
++#define VE_DEC_H265_CTRL_IRQ_MASK \
++	(VE_DEC_H265_CTRL_FINISH_IRQ_EN | VE_DEC_H265_CTRL_ERROR_IRQ_EN | \
++	 VE_DEC_H265_CTRL_VLD_DATA_REQ_IRQ_EN)
++
++#define VE_DEC_H265_TRIGGER			(VE_ENGINE_DEC_H265 + 0x34)
++
++#define VE_DEC_H265_TRIGGER_STCD_VC1		(0x02 << 4)
++#define VE_DEC_H265_TRIGGER_STCD_AVS		(0x01 << 4)
++#define VE_DEC_H265_TRIGGER_STCD_HEVC		(0x00 << 4)
++#define VE_DEC_H265_TRIGGER_DEC_SLICE		(0x08 << 0)
++#define VE_DEC_H265_TRIGGER_INIT_SWDEC		(0x07 << 0)
++#define VE_DEC_H265_TRIGGER_BYTE_ALIGN		(0x06 << 0)
++#define VE_DEC_H265_TRIGGER_GET_VLCUE		(0x05 << 0)
++#define VE_DEC_H265_TRIGGER_GET_VLCSE		(0x04 << 0)
++#define VE_DEC_H265_TRIGGER_FLUSH_BITS		(0x03 << 0)
++#define VE_DEC_H265_TRIGGER_GET_BITS		(0x02 << 0)
++#define VE_DEC_H265_TRIGGER_SHOW_BITS		(0x01 << 0)
++
++#define VE_DEC_H265_STATUS			(VE_ENGINE_DEC_H265 + 0x38)
++
++#define VE_DEC_H265_STATUS_STCD			BIT(24)
++#define VE_DEC_H265_STATUS_STCD_BUSY		BIT(21)
++#define VE_DEC_H265_STATUS_WB_BUSY		BIT(20)
++#define VE_DEC_H265_STATUS_BS_DMA_BUSY		BIT(19)
++#define VE_DEC_H265_STATUS_IQIT_BUSY		BIT(18)
++#define VE_DEC_H265_STATUS_INTER_BUSY		BIT(17)
++#define VE_DEC_H265_STATUS_MORE_DATA		BIT(16)
++#define VE_DEC_H265_STATUS_VLD_BUSY		BIT(14)
++#define VE_DEC_H265_STATUS_DEBLOCKING_BUSY	BIT(13)
++#define VE_DEC_H265_STATUS_DEBLOCKING_DRAM_BUSY	BIT(12)
++#define VE_DEC_H265_STATUS_INTRA_BUSY		BIT(11)
++#define VE_DEC_H265_STATUS_SAO_BUSY		BIT(10)
++#define VE_DEC_H265_STATUS_MVP_BUSY		BIT(9)
++#define VE_DEC_H265_STATUS_SWDEC_BUSY		BIT(8)
++#define VE_DEC_H265_STATUS_OVER_TIME		BIT(3)
++#define VE_DEC_H265_STATUS_VLD_DATA_REQ		BIT(2)
++#define VE_DEC_H265_STATUS_ERROR		BIT(1)
++#define VE_DEC_H265_STATUS_SUCCESS		BIT(0)
++#define VE_DEC_H265_STATUS_STCD_TYPE_MASK	GENMASK(23, 22)
++#define VE_DEC_H265_STATUS_CHECK_MASK \
++	(VE_DEC_H265_STATUS_SUCCESS | VE_DEC_H265_STATUS_ERROR | \
++	 VE_DEC_H265_STATUS_VLD_DATA_REQ)
++#define VE_DEC_H265_STATUS_CHECK_ERROR \
++	(VE_DEC_H265_STATUS_ERROR | VE_DEC_H265_STATUS_VLD_DATA_REQ)
++
++#define VE_DEC_H265_DEC_CTB_NUM			(VE_ENGINE_DEC_H265 + 0x3c)
++
++#define VE_DEC_H265_BITS_ADDR			(VE_ENGINE_DEC_H265 + 0x40)
++
++#define VE_DEC_H265_BITS_ADDR_FIRST_SLICE_DATA	BIT(30)
++#define VE_DEC_H265_BITS_ADDR_LAST_SLICE_DATA	BIT(29)
++#define VE_DEC_H265_BITS_ADDR_VALID_SLICE_DATA	BIT(28)
++#define VE_DEC_H265_BITS_ADDR_BASE(a)		(((a) >> 8) & GENMASK(27, 0))
++
++#define VE_DEC_H265_BITS_OFFSET			(VE_ENGINE_DEC_H265 + 0x44)
++#define VE_DEC_H265_BITS_LEN			(VE_ENGINE_DEC_H265 + 0x48)
++
++#define VE_DEC_H265_BITS_END_ADDR		(VE_ENGINE_DEC_H265 + 0x4c)
++
++#define VE_DEC_H265_BITS_END_ADDR_BASE(a)	((a) >> 8)
++
++#define VE_DEC_H265_SDRT_CTRL			(VE_ENGINE_DEC_H265 + 0x50)
++#define VE_DEC_H265_SDRT_LUMA_ADDR		(VE_ENGINE_DEC_H265 + 0x54)
++#define VE_DEC_H265_SDRT_CHROMA_ADDR		(VE_ENGINE_DEC_H265 + 0x58)
++
++#define VE_DEC_H265_OUTPUT_FRAME_IDX		(VE_ENGINE_DEC_H265 + 0x5c)
++
++#define VE_DEC_H265_NEIGHBOR_INFO_ADDR		(VE_ENGINE_DEC_H265 + 0x60)
++
++#define VE_DEC_H265_NEIGHBOR_INFO_ADDR_BASE(a)	((a) >> 8)
++
++#define VE_DEC_H265_ENTRY_POINT_OFFSET_ADDR	(VE_ENGINE_DEC_H265 + 0x64)
++#define VE_DEC_H265_TILE_START_CTB		(VE_ENGINE_DEC_H265 + 0x68)
++#define VE_DEC_H265_TILE_END_CTB		(VE_ENGINE_DEC_H265 + 0x6c)
++
++#define VE_DEC_H265_LOW_ADDR			(VE_ENGINE_DEC_H265 + 0x80)
++
++#define VE_DEC_H265_LOW_ADDR_PRIMARY_CHROMA(a) \
++	(((a) << 24) & GENMASK(31, 24))
++#define VE_DEC_H265_LOW_ADDR_SECONDARY_CHROMA(a) \
++	(((a) << 16) & GENMASK(23, 16))
++#define VE_DEC_H265_LOW_ADDR_ENTRY_POINTS_BUF(a) \
++	(((a) << 0) & GENMASK(7, 0))
++
++#define VE_DEC_H265_SRAM_OFFSET			(VE_ENGINE_DEC_H265 + 0xe0)
++
++#define VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_LUMA_L0	0x00
++#define VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_CHROMA_L0	0x20
++#define VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_LUMA_L1	0x60
++#define VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_CHROMA_L1	0x80
++#define VE_DEC_H265_SRAM_OFFSET_FRAME_INFO		0x400
++#define VE_DEC_H265_SRAM_OFFSET_FRAME_INFO_UNIT		0x20
++#define VE_DEC_H265_SRAM_OFFSET_SCALING_LISTS		0x800
++#define VE_DEC_H265_SRAM_OFFSET_REF_PIC_LIST0		0xc00
++#define VE_DEC_H265_SRAM_OFFSET_REF_PIC_LIST1		0xc10
++
++#define VE_DEC_H265_SRAM_DATA			(VE_ENGINE_DEC_H265 + 0xe4)
++
++#define VE_DEC_H265_SRAM_DATA_ADDR_BASE(a)	((a) >> 8)
++#define VE_DEC_H265_SRAM_REF_PIC_LIST_LT_REF	BIT(7)
++
+ #define VE_H264_SPS			0x200
+ #define VE_H264_SPS_MBS_ONLY			BIT(18)
+ #define VE_H264_SPS_MB_ADAPTIVE_FRAME_FIELD	BIT(17)
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_video.c b/drivers/staging/media/sunxi/cedrus/cedrus_video.c
+index e2b530b1a..6cc65d85c 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_video.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_video.c
+@@ -41,6 +41,11 @@ static struct cedrus_format cedrus_formats[] = {
+ 		.pixelformat	= V4L2_PIX_FMT_H264_SLICE_RAW,
+ 		.directions	= CEDRUS_DECODE_SRC,
+ 	},
++	{
++		.pixelformat	= V4L2_PIX_FMT_HEVC_SLICE,
++		.directions	= CEDRUS_DECODE_SRC,
++		.capabilities	= CEDRUS_CAPABILITY_H265_DEC,
++	},
+ 	{
+ 		.pixelformat	= V4L2_PIX_FMT_SUNXI_TILED_NV12,
+ 		.directions	= CEDRUS_DECODE_DST,
+@@ -105,6 +110,7 @@ static void cedrus_prepare_format(struct v4l2_pix_format *pix_fmt)
+ 	switch (pix_fmt->pixelformat) {
+ 	case V4L2_PIX_FMT_MPEG2_SLICE:
+ 	case V4L2_PIX_FMT_H264_SLICE_RAW:
++	case V4L2_PIX_FMT_HEVC_SLICE:
+ 		/* Zero bytes per line for encoded source. */
+ 		bytesperline = 0;
+ 
+@@ -473,6 +479,10 @@ static int cedrus_start_streaming(struct vb2_queue *vq, unsigned int count)
+ 		ctx->current_codec = CEDRUS_CODEC_H264;
+ 		break;
+ 
++	case V4L2_PIX_FMT_HEVC_SLICE:
++		ctx->current_codec = CEDRUS_CODEC_H265;
++		break;
++
+ 	default:
+ 		return -EINVAL;
+ 	}
+diff --git a/include/media/hevc-ctrls.h b/include/media/hevc-ctrls.h
+new file mode 100644
+index 000000000..2de83d9f6
+--- /dev/null
++++ b/include/media/hevc-ctrls.h
+@@ -0,0 +1,185 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * These are the HEVC state controls for use with stateless HEVC
++ * codec drivers.
++ *
++ * It turns out that these structs are not stable yet and will undergo
++ * more changes. So keep them private until they are stable and ready to
++ * become part of the official public API.
++ */
++
++#ifndef _HEVC_CTRLS_H_
++#define _HEVC_CTRLS_H_
++
++/* The pixel format isn't stable at the moment and will likely be renamed. */
++#define V4L2_PIX_FMT_HEVC_SLICE v4l2_fourcc('S', '2', '6', '5') /* HEVC parsed slices */
++
++#define V4L2_CID_MPEG_VIDEO_HEVC_SPS		(V4L2_CID_MPEG_BASE + 1008)
++#define V4L2_CID_MPEG_VIDEO_HEVC_PPS		(V4L2_CID_MPEG_BASE + 1009)
++#define V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS	(V4L2_CID_MPEG_BASE + 1010)
++
++/* enum v4l2_ctrl_type type values */
++#define V4L2_CTRL_TYPE_HEVC_SPS 0x0120
++#define V4L2_CTRL_TYPE_HEVC_PPS 0x0121
++#define V4L2_CTRL_TYPE_HEVC_SLICE_PARAMS 0x0122
++
++#define V4L2_HEVC_SLICE_TYPE_B	0
++#define V4L2_HEVC_SLICE_TYPE_P	1
++#define V4L2_HEVC_SLICE_TYPE_I	2
++
++/* The controls are not stable at the moment and will likely be reworked. */
++struct v4l2_ctrl_hevc_sps {
++	/* ISO/IEC 23008-2, ITU-T Rec. H.265: Sequence parameter set */
++	__u8	chroma_format_idc;
++	__u8	separate_colour_plane_flag;
++	__u16	pic_width_in_luma_samples;
++	__u16	pic_height_in_luma_samples;
++	__u8	bit_depth_luma_minus8;
++	__u8	bit_depth_chroma_minus8;
++	__u8	log2_max_pic_order_cnt_lsb_minus4;
++	__u8	sps_max_dec_pic_buffering_minus1;
++	__u8	sps_max_num_reorder_pics;
++	__u8	sps_max_latency_increase_plus1;
++	__u8	log2_min_luma_coding_block_size_minus3;
++	__u8	log2_diff_max_min_luma_coding_block_size;
++	__u8	log2_min_luma_transform_block_size_minus2;
++	__u8	log2_diff_max_min_luma_transform_block_size;
++	__u8	max_transform_hierarchy_depth_inter;
++	__u8	max_transform_hierarchy_depth_intra;
++	__u8	scaling_list_enabled_flag;
++	__u8	amp_enabled_flag;
++	__u8	sample_adaptive_offset_enabled_flag;
++	__u8	pcm_enabled_flag;
++	__u8	pcm_sample_bit_depth_luma_minus1;
++	__u8	pcm_sample_bit_depth_chroma_minus1;
++	__u8	log2_min_pcm_luma_coding_block_size_minus3;
++	__u8	log2_diff_max_min_pcm_luma_coding_block_size;
++	__u8	pcm_loop_filter_disabled_flag;
++	__u8	num_short_term_ref_pic_sets;
++	__u8	long_term_ref_pics_present_flag;
++	__u8	num_long_term_ref_pics_sps;
++	__u8	sps_temporal_mvp_enabled_flag;
++	__u8	strong_intra_smoothing_enabled_flag;
++};
++
++struct v4l2_ctrl_hevc_pps {
++	/* ISO/IEC 23008-2, ITU-T Rec. H.265: Picture parameter set */
++	__u8	dependent_slice_segment_flag;
++	__u8	output_flag_present_flag;
++	__u8	num_extra_slice_header_bits;
++	__u8	sign_data_hiding_enabled_flag;
++	__u8	cabac_init_present_flag;
++	__s8	init_qp_minus26;
++	__u8	constrained_intra_pred_flag;
++	__u8	transform_skip_enabled_flag;
++	__u8	cu_qp_delta_enabled_flag;
++	__u8	diff_cu_qp_delta_depth;
++	__s8	pps_cb_qp_offset;
++	__s8	pps_cr_qp_offset;
++	__u8	pps_slice_chroma_qp_offsets_present_flag;
++	__u8	weighted_pred_flag;
++	__u8	weighted_bipred_flag;
++	__u8	transquant_bypass_enabled_flag;
++	__u8	tiles_enabled_flag;
++	__u8	entropy_coding_sync_enabled_flag;
++	__u8	num_tile_columns_minus1;
++	__u8	num_tile_rows_minus1;
++	__u8	column_width_minus1[20];
++	__u8	row_height_minus1[22];
++	__u8	loop_filter_across_tiles_enabled_flag;
++	__u8	pps_loop_filter_across_slices_enabled_flag;
++	__u8	deblocking_filter_override_enabled_flag;
++	__u8	pps_disable_deblocking_filter_flag;
++	__s8	pps_beta_offset_div2;
++	__s8	pps_tc_offset_div2;
++	__u8	lists_modification_present_flag;
++	__u8	log2_parallel_merge_level_minus2;
++	__u8	slice_segment_header_extension_present_flag;
++	__u8	padding;
++};
++
++#define V4L2_HEVC_DPB_ENTRY_RPS_ST_CURR_BEFORE	0x01
++#define V4L2_HEVC_DPB_ENTRY_RPS_ST_CURR_AFTER	0x02
++#define V4L2_HEVC_DPB_ENTRY_RPS_LT_CURR		0x03
++
++#define V4L2_HEVC_DPB_ENTRIES_NUM_MAX		16
++
++struct v4l2_hevc_dpb_entry {
++	__u64	timestamp;
++	__u8	rps;
++	__u8	field_pic;
++	__u16	pic_order_cnt[2];
++	__u8	padding[2];
++};
++
++struct v4l2_hevc_pred_weight_table {
++	__u8	luma_log2_weight_denom;
++	__s8	delta_chroma_log2_weight_denom;
++
++	__s8	delta_luma_weight_l0[V4L2_HEVC_DPB_ENTRIES_NUM_MAX];
++	__s8	luma_offset_l0[V4L2_HEVC_DPB_ENTRIES_NUM_MAX];
++	__s8	delta_chroma_weight_l0[V4L2_HEVC_DPB_ENTRIES_NUM_MAX][2];
++	__s8	chroma_offset_l0[V4L2_HEVC_DPB_ENTRIES_NUM_MAX][2];
++
++	__s8	delta_luma_weight_l1[V4L2_HEVC_DPB_ENTRIES_NUM_MAX];
++	__s8	luma_offset_l1[V4L2_HEVC_DPB_ENTRIES_NUM_MAX];
++	__s8	delta_chroma_weight_l1[V4L2_HEVC_DPB_ENTRIES_NUM_MAX][2];
++	__s8	chroma_offset_l1[V4L2_HEVC_DPB_ENTRIES_NUM_MAX][2];
++
++	__u8	padding[2];
++};
++
++struct v4l2_ctrl_hevc_slice_params {
++	__u32	bit_size;
++	__u32	data_bit_offset;
++
++	/* ISO/IEC 23008-2, ITU-T Rec. H.265: NAL unit header */
++	__u8	nal_unit_type;
++	__u8	nuh_temporal_id_plus1;
++
++	/* ISO/IEC 23008-2, ITU-T Rec. H.265: General slice segment header */
++	__u8	slice_type;
++	__u8	colour_plane_id;
++	__u16	slice_pic_order_cnt;
++	__u8	slice_sao_luma_flag;
++	__u8	slice_sao_chroma_flag;
++	__u8	slice_temporal_mvp_enabled_flag;
++	__u8	num_ref_idx_l0_active_minus1;
++	__u8	num_ref_idx_l1_active_minus1;
++	__u8	mvd_l1_zero_flag;
++	__u8	cabac_init_flag;
++	__u8	collocated_from_l0_flag;
++	__u8	collocated_ref_idx;
++	__u8	five_minus_max_num_merge_cand;
++	__u8	use_integer_mv_flag;
++	__s8	slice_qp_delta;
++	__s8	slice_cb_qp_offset;
++	__s8	slice_cr_qp_offset;
++	__s8	slice_act_y_qp_offset;
++	__s8	slice_act_cb_qp_offset;
++	__s8	slice_act_cr_qp_offset;
++	__u8	slice_deblocking_filter_disabled_flag;
++	__s8	slice_beta_offset_div2;
++	__s8	slice_tc_offset_div2;
++	__u8	slice_loop_filter_across_slices_enabled_flag;
++
++	/* ISO/IEC 23008-2, ITU-T Rec. H.265: Picture timing SEI message */
++	__u8	pic_struct;
++
++	/* ISO/IEC 23008-2, ITU-T Rec. H.265: General slice segment header */
++	struct v4l2_hevc_dpb_entry dpb[V4L2_HEVC_DPB_ENTRIES_NUM_MAX];
++	__u8	num_active_dpb_entries;
++	__u8	ref_idx_l0[V4L2_HEVC_DPB_ENTRIES_NUM_MAX];
++	__u8	ref_idx_l1[V4L2_HEVC_DPB_ENTRIES_NUM_MAX];
++
++	__u8	num_rps_poc_st_curr_before;
++	__u8	num_rps_poc_st_curr_after;
++	__u8	num_rps_poc_lt_curr;
++
++	/* ISO/IEC 23008-2, ITU-T Rec. H.265: Weighted prediction parameter */
++	struct v4l2_hevc_pred_weight_table pred_weight_table;
++
++	__u8	padding[2];
++};
++
++#endif
+diff --git a/include/media/v4l2-ctrls.h b/include/media/v4l2-ctrls.h
+index b4433483a..34761e84a 100644
+--- a/include/media/v4l2-ctrls.h
++++ b/include/media/v4l2-ctrls.h
+@@ -20,6 +20,7 @@
+ #include <media/mpeg2-ctrls.h>
+ #include <media/fwht-ctrls.h>
+ #include <media/h264-ctrls.h>
++#include <media/hevc-ctrls.h>
+ 
+ /* forward references */
+ struct file;
+@@ -48,6 +49,9 @@ struct poll_table_struct;
+  * @p_h264_scaling_matrix:	Pointer to a struct v4l2_ctrl_h264_scaling_matrix.
+  * @p_h264_slice_params:	Pointer to a struct v4l2_ctrl_h264_slice_params.
+  * @p_h264_decode_params:	Pointer to a struct v4l2_ctrl_h264_decode_params.
++ * @p_hevc_sps:			Pointer to an HEVC sequence parameter set structure.
++ * @p_hevc_pps:			Pointer to an HEVC picture parameter set structure.
++ * @p_hevc_slice_params		Pointer to an HEVC slice parameters structure.
+  * @p:				Pointer to a compound value.
+  */
+ union v4l2_ctrl_ptr {
+@@ -65,6 +69,9 @@ union v4l2_ctrl_ptr {
+ 	struct v4l2_ctrl_h264_scaling_matrix *p_h264_scaling_matrix;
+ 	struct v4l2_ctrl_h264_slice_params *p_h264_slice_params;
+ 	struct v4l2_ctrl_h264_decode_params *p_h264_decode_params;
++	struct v4l2_ctrl_hevc_sps *p_hevc_sps;
++	struct v4l2_ctrl_hevc_pps *p_hevc_pps;
++	struct v4l2_ctrl_hevc_slice_params *p_hevc_slice_params;
+ 	void *p;
+ };
+ 
+-- 
+2.17.1
+

--- a/patch/kernel/sunxi-next-olinuxino/0153-fix-decoding-some-h264.patch
+++ b/patch/kernel/sunxi-next-olinuxino/0153-fix-decoding-some-h264.patch
@@ -1,0 +1,79 @@
+From 130f389dc8f9bc2cd8f4cfd4e6f258612a8db4d9 Mon Sep 17 00:00:00 2001
+From: hehopmajieh <hehopmajieh@debian.bg>
+Date: Fri, 3 Jan 2020 23:27:58 +0200
+Subject: [PATCH 3/7] media: cedrus: Fix decoding for some H264 videos Based on
+ From 443ca53cf78c635aa5bebe9f115721e55fe9ca38 Mon Sep 17 00:00:00 2001 From:
+ Jernej Skrabec <jernej.skrabec@siol.net> Date: Sat, 25 May 2019 12:33:05
+ +0200 Subject: [PATCH] media: cedrus: Fix decoding for some H264 videos
+
+It seems that for some H264 videos at least one bitstream parsing
+trigger must be called in order to be decoded correctly. There is no
+explanation why this helps, but it was observed that two sample videos
+with this fix are now decoded correctly and there is no regression with
+others.
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ .../staging/media/sunxi/cedrus/cedrus_h264.c  | 22 ++++++++++++++++---
+ 1 file changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+index a30bb283f..fab14de18 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+@@ -6,6 +6,7 @@
+  * Copyright (c) 2018 Bootlin
+  */
+ 
++#include <linux/delay.h>
+ #include <linux/types.h>
+ 
+ #include <media/videobuf2-dma-contig.h>
+@@ -289,6 +290,20 @@ static void cedrus_write_pred_weight_table(struct cedrus_ctx *ctx,
+ 	}
+ }
+ 
++static void cedrus_skip_bits(struct cedrus_dev *dev, int num)
++{
++	for (; num > 32; num -= 32) {
++		cedrus_write(dev, VE_H264_TRIGGER_TYPE, 0x3 | (32 << 8));
++		while (cedrus_read(dev, VE_H264_STATUS) & (1 << 8))
++			udelay(1);
++	}
++	if (num > 0) {
++		cedrus_write(dev, VE_H264_TRIGGER_TYPE, 0x3 | (num << 8));
++		while (cedrus_read(dev, VE_H264_STATUS) & (1 << 8))
++			udelay(1);
++	}
++}
++
+ static void cedrus_set_params(struct cedrus_ctx *ctx,
+ 			      struct cedrus_run *run)
+ {
+@@ -299,12 +314,11 @@ static void cedrus_set_params(struct cedrus_ctx *ctx,
+ 	struct vb2_buffer *src_buf = &run->src->vb2_buf;
+ 	struct cedrus_dev *dev = ctx->dev;
+ 	dma_addr_t src_buf_addr;
+-	u32 offset = slice->header_bit_size;
+-	u32 len = (slice->size * 8) - offset;
++	u32 len = slice->size * 8;
+ 	u32 reg;
+ 
+ 	cedrus_write(dev, VE_H264_VLD_LEN, len);
+-	cedrus_write(dev, VE_H264_VLD_OFFSET, offset);
++	cedrus_write(dev, VE_H264_VLD_OFFSET, 0);
+ 
+ 	src_buf_addr = vb2_dma_contig_plane_dma_addr(src_buf, 0);
+ 	cedrus_write(dev, VE_H264_VLD_END,
+@@ -323,6 +337,8 @@ static void cedrus_set_params(struct cedrus_ctx *ctx,
+ 	cedrus_write(dev, VE_H264_TRIGGER_TYPE,
+ 		     VE_H264_TRIGGER_TYPE_INIT_SWDEC);
+ 
++	cedrus_skip_bits(dev, slice->header_bit_size);
++
+ 	if (((pps->flags & V4L2_H264_PPS_FLAG_WEIGHTED_PRED) &&
+ 	     (slice->slice_type == V4L2_H264_SLICE_TYPE_P ||
+ 	      slice->slice_type == V4L2_H264_SLICE_TYPE_SP)) ||
+-- 
+2.17.1
+

--- a/patch/kernel/sunxi-next-olinuxino/0154-media-cedrus-fix-h264-def-reference.patch
+++ b/patch/kernel/sunxi-next-olinuxino/0154-media-cedrus-fix-h264-def-reference.patch
@@ -1,0 +1,40 @@
+From d5f1dfc5ee3f083ff77610cdc2212da951f56117 Mon Sep 17 00:00:00 2001
+From: hehopmajieh <hehopmajieh@debian.bg>
+Date: Fri, 3 Jan 2020 23:29:49 +0200
+Subject: [PATCH 4/7] media: cedrus: Fix H264 default reference index countwq
+ From fce7f7e700176b402b303d2a62813cc0cdd061e0 Mon Sep 17 00:00:00 2001 From:
+ Jernej Skrabec <jernej.skrabec@siol.net> Date: Sat, 25 May 2019 13:18:50
+ +0200 Subject: [PATCH 2/5] media: cedrus: Fix H264 default reference index
+ count
+
+Reference index count in VE_H264_PPS should come from PPS control.
+However, this is not really important, because reference index count is
+in our case always overridden by that from slice header.
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ drivers/staging/media/sunxi/cedrus/cedrus_h264.c | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+index fab14de18..d0ee3f90f 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+@@ -356,12 +356,8 @@ static void cedrus_set_params(struct cedrus_ctx *ctx,
+ 
+ 	// picture parameters
+ 	reg = 0;
+-	/*
+-	 * FIXME: the kernel headers are allowing the default value to
+-	 * be passed, but the libva doesn't give us that.
+-	 */
+-	reg |= (slice->num_ref_idx_l0_active_minus1 & 0x1f) << 10;
+-	reg |= (slice->num_ref_idx_l1_active_minus1 & 0x1f) << 5;
++	reg |= (pps->num_ref_idx_l0_default_active_minus1 & 0x1f) << 10;
++	reg |= (pps->num_ref_idx_l1_default_active_minus1 & 0x1f) << 5;
+ 	reg |= (pps->weighted_bipred_idc & 0x3) << 2;
+ 	if (pps->flags & V4L2_H264_PPS_FLAG_ENTROPY_CODING_MODE)
+ 		reg |= VE_H264_PPS_ENTROPY_CODING_MODE;
+-- 
+2.17.1
+

--- a/patch/kernel/sunxi-next-olinuxino/0155-media-cedrus-WIP-h264-improvements.patch
+++ b/patch/kernel/sunxi-next-olinuxino/0155-media-cedrus-WIP-h264-improvements.patch
@@ -1,0 +1,127 @@
+From 7bccfb56f2cc23b5722d61f82a9ad047474fe0f7 Mon Sep 17 00:00:00 2001
+From: hehopmajieh <hehopmajieh@debian.bg>
+Date: Fri, 3 Jan 2020 23:31:21 +0200
+Subject: [PATCH 5/7] media: cedrus: WIP H264 improvements From
+ 9714cf1bc8c5b48f21af3500e34497621b51a4b1 Mon Sep 17 00:00:00 2001 From:
+ Jernej Skrabec <jernej.skrabec@siol.net> Date: Thu, 14 Feb 2019 22:50:12
+ +0100 Subject: [PATCH 3/5] media: cedrus: WIP H264 improvements
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ .../staging/media/sunxi/cedrus/cedrus_h264.c  | 37 ++++++++++++++-----
+ 1 file changed, 27 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+index d0ee3f90f..dcb8d3837 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+@@ -39,7 +39,7 @@ struct cedrus_h264_sram_ref_pic {
+ #define CEDRUS_H264_FRAME_NUM		18
+ 
+ #define CEDRUS_NEIGHBOR_INFO_BUF_SIZE	(16 * SZ_1K)
+-#define CEDRUS_PIC_INFO_BUF_SIZE	(128 * SZ_1K)
++#define CEDRUS_PIC_INFO_BUF_SIZE	(336 * SZ_1K)
+ 
+ static void cedrus_h264_write_sram(struct cedrus_dev *dev,
+ 				   enum cedrus_h264_sram_off off,
+@@ -102,7 +102,7 @@ static void cedrus_write_frame_list(struct cedrus_ctx *ctx,
+ 	struct cedrus_dev *dev = ctx->dev;
+ 	unsigned long used_dpbs = 0;
+ 	unsigned int position;
+-	unsigned int output = 0;
++	int output = -1;
+ 	unsigned int i;
+ 
+ 	memset(pic_list, 0, sizeof(pic_list));
+@@ -123,6 +123,11 @@ static void cedrus_write_frame_list(struct cedrus_ctx *ctx,
+ 		position = cedrus_buf->codec.h264.position;
+ 		used_dpbs |= BIT(position);
+ 
++		if (run->dst->vb2_buf.timestamp == dpb->reference_ts) {
++			output = position;
++			continue;
++		}
++
+ 		if (!(dpb->flags & V4L2_H264_DPB_ENTRY_FLAG_ACTIVE))
+ 			continue;
+ 
+@@ -130,13 +135,11 @@ static void cedrus_write_frame_list(struct cedrus_ctx *ctx,
+ 				    dpb->top_field_order_cnt,
+ 				    dpb->bottom_field_order_cnt,
+ 				    &pic_list[position]);
+-
+-		output = max(position, output);
+ 	}
+ 
+-	position = find_next_zero_bit(&used_dpbs, CEDRUS_H264_FRAME_NUM,
+-				      output);
+-	if (position >= CEDRUS_H264_FRAME_NUM)
++	if (output >= 0)
++		position = output;
++	else
+ 		position = find_first_zero_bit(&used_dpbs, CEDRUS_H264_FRAME_NUM);
+ 
+ 	output_buf = vb2_to_cedrus_buffer(&run->dst->vb2_buf);
+@@ -162,6 +165,10 @@ static void cedrus_write_frame_list(struct cedrus_ctx *ctx,
+ 
+ #define CEDRUS_MAX_REF_IDX	32
+ 
++#define REF_IDX(v)		(v & GENMASK(5, 0))
++#define REF_FIELD(v)		(v >> 6)
++#define REF_FIELD_BOTTOM	2
++
+ static void _cedrus_write_ref_list(struct cedrus_ctx *ctx,
+ 				   struct cedrus_run *run,
+ 				   const u8 *ref_list, u8 num_ref,
+@@ -184,7 +191,7 @@ static void _cedrus_write_ref_list(struct cedrus_ctx *ctx,
+ 		int buf_idx;
+ 		u8 dpb_idx;
+ 
+-		dpb_idx = ref_list[i];
++		dpb_idx = REF_IDX(ref_list[i]);
+ 		dpb = &decode->dpb[dpb_idx];
+ 
+ 		if (!(dpb->flags & V4L2_H264_DPB_ENTRY_FLAG_ACTIVE))
+@@ -199,7 +206,8 @@ static void _cedrus_write_ref_list(struct cedrus_ctx *ctx,
+ 		position = cedrus_buf->codec.h264.position;
+ 
+ 		sram_array[i] |= position << 1;
+-		if (ref_buf->field == V4L2_FIELD_BOTTOM)
++		/* set bottom field flag when reference is to bottom field */
++		if (REF_FIELD(ref_list[i]) == REF_FIELD_BOTTOM)
+ 			sram_array[i] |= BIT(0);
+ 	}
+ 
+@@ -315,6 +323,8 @@ static void cedrus_set_params(struct cedrus_ctx *ctx,
+ 	struct cedrus_dev *dev = ctx->dev;
+ 	dma_addr_t src_buf_addr;
+ 	u32 len = slice->size * 8;
++	unsigned int pic_width_in_mbs;
++	bool mbaff_picture;
+ 	u32 reg;
+ 
+ 	cedrus_write(dev, VE_H264_VLD_LEN, len);
+@@ -382,12 +392,19 @@ static void cedrus_set_params(struct cedrus_ctx *ctx,
+ 		reg |= VE_H264_SPS_DIRECT_8X8_INFERENCE;
+ 	cedrus_write(dev, VE_H264_SPS, reg);
+ 
++	mbaff_picture = !(slice->flags & V4L2_H264_SLICE_FLAG_FIELD_PIC) &&
++			(sps->flags & V4L2_H264_SPS_FLAG_MB_ADAPTIVE_FRAME_FIELD);
++	pic_width_in_mbs = sps->pic_width_in_mbs_minus1 + 1;
++
+ 	// slice parameters
+ 	reg = 0;
++	reg |= ((slice->first_mb_in_slice % pic_width_in_mbs) & 0xff) << 24;
++	reg |= (((slice->first_mb_in_slice / pic_width_in_mbs) * (mbaff_picture ? 2 : 1)) & 0xff)  << 16;
+ 	reg |= decode->nal_ref_idc ? BIT(12) : 0;
+ 	reg |= (slice->slice_type & 0xf) << 8;
+ 	reg |= slice->cabac_init_idc & 0x3;
+-	reg |= VE_H264_SHS_FIRST_SLICE_IN_PIC;
++	if (decode->num_slices == 1)
++		reg |= VE_H264_SHS_FIRST_SLICE_IN_PIC;
+ 	if (slice->flags & V4L2_H264_SLICE_FLAG_FIELD_PIC)
+ 		reg |= VE_H264_SHS_FIELD_PIC;
+ 	if (slice->flags & V4L2_H264_SLICE_FLAG_BOTTOM_FIELD)
+-- 
+2.17.1
+

--- a/patch/kernel/sunxi-next-olinuxino/0156-WIP-HEVC-improvements.patch
+++ b/patch/kernel/sunxi-next-olinuxino/0156-WIP-HEVC-improvements.patch
@@ -1,0 +1,740 @@
+From 233c1c07a8801685f0ee3532b28ed248d0b3e690 Mon Sep 17 00:00:00 2001
+From: hehopmajieh <hehopmajieh@debian.bg>
+Date: Fri, 3 Jan 2020 23:33:00 +0200
+Subject: [PATCH 6/7] WIP: HEVC improvements From
+ c6582c38df2f78dc9d4f8fd920780a82a01e4d8e Mon Sep 17 00:00:00 2001 From:
+ Jernej Skrabec <jernej.skrabec@siol.net> Date: Sat, 25 May 2019 13:58:17
+ +0200 Subject: [PATCH 2/3] WIP: HEVC improvements
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ drivers/media/v4l2-core/v4l2-ctrls.c          |   8 +
+ drivers/staging/media/sunxi/cedrus/cedrus.c   |   6 +
+ drivers/staging/media/sunxi/cedrus/cedrus.h   |  11 +-
+ .../staging/media/sunxi/cedrus/cedrus_dec.c   |   2 +
+ .../staging/media/sunxi/cedrus/cedrus_h265.c  | 348 +++++++++++++-----
+ .../staging/media/sunxi/cedrus/cedrus_regs.h  |   3 +
+ .../staging/media/sunxi/cedrus/cedrus_video.c |  12 +-
+ include/media/hevc-ctrls.h                    |  20 +-
+ 8 files changed, 301 insertions(+), 109 deletions(-)
+
+diff --git a/drivers/media/v4l2-core/v4l2-ctrls.c b/drivers/media/v4l2-core/v4l2-ctrls.c
+index 67361742c..787c6f491 100644
+--- a/drivers/media/v4l2-core/v4l2-ctrls.c
++++ b/drivers/media/v4l2-core/v4l2-ctrls.c
+@@ -935,6 +935,7 @@ const char *v4l2_ctrl_get_name(u32 id)
+ 	case V4L2_CID_MPEG_VIDEO_HEVC_SPS:			return "HEVC Sequence Parameter Set";
+ 	case V4L2_CID_MPEG_VIDEO_HEVC_PPS:			return "HEVC Picture Parameter Set";
+ 	case V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS:		return "HEVC Slice Parameters";
++	case V4L2_CID_MPEG_VIDEO_HEVC_SCALING_MATRIX:		return "HEVC Scaling Matrix";
+ 
+ 	/* CAMERA controls */
+ 	/* Keep the order of the 'case's the same as in v4l2-controls.h! */
+@@ -1356,6 +1357,9 @@ void v4l2_ctrl_fill(u32 id, const char **name, enum v4l2_ctrl_type *type,
+ 	case V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS:
+ 		*type = V4L2_CTRL_TYPE_HEVC_SLICE_PARAMS;
+ 		break;
++	case V4L2_CID_MPEG_VIDEO_HEVC_SCALING_MATRIX:
++		*type = V4L2_CTRL_TYPE_HEVC_SCALING_MATRIX;
++		break;
+ 	default:
+ 		*type = V4L2_CTRL_TYPE_INTEGER;
+ 		break;
+@@ -1735,6 +1739,7 @@ static int std_validate(const struct v4l2_ctrl *ctrl, u32 idx,
+ 	case V4L2_CTRL_TYPE_HEVC_SPS:
+ 	case V4L2_CTRL_TYPE_HEVC_PPS:
+ 	case V4L2_CTRL_TYPE_HEVC_SLICE_PARAMS:
++	case V4L2_CTRL_TYPE_HEVC_SCALING_MATRIX:
+ 		return 0;
+ 
+ 	default:
+@@ -2344,6 +2349,9 @@ static struct v4l2_ctrl *v4l2_ctrl_new(struct v4l2_ctrl_handler *hdl,
+ 	case V4L2_CTRL_TYPE_HEVC_SLICE_PARAMS:
+ 		elem_size = sizeof(struct v4l2_ctrl_hevc_slice_params);
+ 		break;
++	case V4L2_CTRL_TYPE_HEVC_SCALING_MATRIX:
++		elem_size = sizeof(struct v4l2_ctrl_hevc_scaling_matrix);
++		break;
+ 	default:
+ 		if (type < V4L2_CTRL_COMPOUND_TYPES)
+ 			elem_size = sizeof(s32);
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus.c b/drivers/staging/media/sunxi/cedrus/cedrus.c
+index 70642834f..01860f247 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus.c
+@@ -88,6 +88,12 @@ static const struct cedrus_control cedrus_controls[] = {
+ 		.codec		= CEDRUS_CODEC_H265,
+ 		.required	= true,
+ 	},
++	{
++		.id		= V4L2_CID_MPEG_VIDEO_HEVC_SCALING_MATRIX,
++		.elem_size	= sizeof(struct v4l2_ctrl_hevc_scaling_matrix),
++		.codec		= CEDRUS_CODEC_H265,
++		.required	= true,
++	},
+ };
+ 
+ #define CEDRUS_CONTROLS_COUNT	ARRAY_SIZE(cedrus_controls)
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus.h b/drivers/staging/media/sunxi/cedrus/cedrus.h
+index f19be772d..b518c5613 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus.h
++++ b/drivers/staging/media/sunxi/cedrus/cedrus.h
+@@ -74,6 +74,7 @@ struct cedrus_h265_run {
+ 	const struct v4l2_ctrl_hevc_sps			*sps;
+ 	const struct v4l2_ctrl_hevc_pps			*pps;
+ 	const struct v4l2_ctrl_hevc_slice_params	*slice_params;
++	const struct v4l2_ctrl_hevc_scaling_matrix	*scaling_matrix;
+ };
+ 
+ struct cedrus_run {
+@@ -90,6 +91,10 @@ struct cedrus_run {
+ struct cedrus_buffer {
+ 	struct v4l2_m2m_buffer          m2m_buf;
+ 
++	void		*mv_col_buf;
++	dma_addr_t	mv_col_buf_dma;
++	ssize_t		mv_col_buf_size;
++
+ 	union {
+ 		struct {
+ 			unsigned int			position;
+@@ -123,12 +128,10 @@ struct cedrus_ctx {
+ 			dma_addr_t	neighbor_info_buf_dma;
+ 		} h264;
+ 		struct {
+-			void		*mv_col_buf;
+-			dma_addr_t	mv_col_buf_addr;
+-			ssize_t		mv_col_buf_size;
+-			ssize_t		mv_col_buf_unit_size;
+ 			void		*neighbor_info_buf;
+ 			dma_addr_t	neighbor_info_buf_addr;
++			void		*entry_points_buf;
++			dma_addr_t	entry_points_buf_addr;
+ 		} h265;
+ 	} codec;
+ };
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_dec.c b/drivers/staging/media/sunxi/cedrus/cedrus_dec.c
+index c6d0ef66c..104adb084 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_dec.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_dec.c
+@@ -66,6 +66,8 @@ void cedrus_device_run(void *priv)
+ 			V4L2_CID_MPEG_VIDEO_HEVC_PPS);
+ 		run.h265.slice_params = cedrus_find_control_data(ctx,
+ 			V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS);
++		run.h265.scaling_matrix = cedrus_find_control_data(ctx,
++			V4L2_CID_MPEG_VIDEO_HEVC_SCALING_MATRIX);
+ 		break;
+ 
+ 	default:
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_h265.c b/drivers/staging/media/sunxi/cedrus/cedrus_h265.c
+index fd4d86b02..82d29c59b 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_h265.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_h265.c
+@@ -77,24 +77,25 @@ static void cedrus_h265_sram_write_offset(struct cedrus_dev *dev, u32 offset)
+ 	cedrus_write(dev, VE_DEC_H265_SRAM_OFFSET, offset);
+ }
+ 
+-static void cedrus_h265_sram_write_data(struct cedrus_dev *dev, void *data,
++static void cedrus_h265_sram_write_data(struct cedrus_dev *dev, const void *data,
+ 					unsigned int size)
+ {
+-	u32 *word = data;
++	size_t count = DIV_ROUND_UP(size, 4);
++	const u32 *word = data;
+ 
+-	while (size >= sizeof(u32)) {
++	while (count--)
+ 		cedrus_write(dev, VE_DEC_H265_SRAM_DATA, *word++);
+-		size -= sizeof(u32);
+-	}
+ }
+ 
+ static inline dma_addr_t
+ cedrus_h265_frame_info_mv_col_buf_addr(struct cedrus_ctx *ctx,
+-				       unsigned int index, unsigned int field)
++				       unsigned int index)
+ {
+-	return ctx->codec.h265.mv_col_buf_addr + index *
+-	       ctx->codec.h265.mv_col_buf_unit_size +
+-	       field * ctx->codec.h265.mv_col_buf_unit_size / 2;
++	struct cedrus_buffer *cedrus_buf;
++
++	cedrus_buf = vb2_to_cedrus_buffer(ctx->dst_bufs[index]);
++
++	return cedrus_buf->mv_col_buf_dma;
+ }
+ 
+ static void cedrus_h265_frame_info_write_single(struct cedrus_ctx *ctx,
+@@ -107,9 +108,8 @@ static void cedrus_h265_frame_info_write_single(struct cedrus_ctx *ctx,
+ 	dma_addr_t dst_luma_addr = cedrus_dst_buf_addr(ctx, buffer_index, 0);
+ 	dma_addr_t dst_chroma_addr = cedrus_dst_buf_addr(ctx, buffer_index, 1);
+ 	dma_addr_t mv_col_buf_addr[2] = {
+-		cedrus_h265_frame_info_mv_col_buf_addr(ctx, buffer_index, 0),
+-		cedrus_h265_frame_info_mv_col_buf_addr(ctx, buffer_index,
+-						       field_pic ? 1 : 0)
++		cedrus_h265_frame_info_mv_col_buf_addr(ctx, buffer_index),
++		cedrus_h265_frame_info_mv_col_buf_addr(ctx, buffer_index)
+ 	};
+ 	u32 offset = VE_DEC_H265_SRAM_OFFSET_FRAME_INFO +
+ 		     VE_DEC_H265_SRAM_OFFSET_FRAME_INFO_UNIT * index;
+@@ -158,28 +158,24 @@ static void cedrus_h265_ref_pic_list_write(struct cedrus_dev *dev,
+ 					   u8 num_ref_idx_active,
+ 					   u32 sram_offset)
+ {
++	u8 sram_array[V4L2_HEVC_DPB_ENTRIES_NUM_MAX];
+ 	unsigned int i;
+-	u32 word = 0;
++
++	memset(sram_array, 0, sizeof(sram_array));
++	num_ref_idx_active = min(num_ref_idx_active,
++				 (u8)V4L2_HEVC_DPB_ENTRIES_NUM_MAX);
+ 
+ 	cedrus_h265_sram_write_offset(dev, sram_offset);
+ 
+ 	for (i = 0; i < num_ref_idx_active; i++) {
+-		unsigned int shift = (i % 4) * 8;
+ 		unsigned int index = list[i];
+-		u8 value = list[i];
+ 
++		sram_array[i] = index;
+ 		if (dpb[index].rps == V4L2_HEVC_DPB_ENTRY_RPS_LT_CURR)
+-			value |= VE_DEC_H265_SRAM_REF_PIC_LIST_LT_REF;
+-
+-		/* Each SRAM word gathers up to 4 references. */
+-		word |= value << shift;
+-
+-		/* Write the word to SRAM and clear it for the next batch. */
+-		if ((i % 4) == 3 || i == (num_ref_idx_active - 1)) {
+-			cedrus_h265_sram_write_data(dev, &word, sizeof(word));
+-			word = 0;
+-		}
++			sram_array[i] |= VE_DEC_H265_SRAM_REF_PIC_LIST_LT_REF;
+ 	}
++
++	cedrus_h265_sram_write_data(dev, &sram_array, num_ref_idx_active);
+ }
+ 
+ static void cedrus_h265_pred_weight_write(struct cedrus_dev *dev,
+@@ -220,6 +216,131 @@ static void cedrus_h265_pred_weight_write(struct cedrus_dev *dev,
+ 	}
+ }
+ 
++static void cedrus_h265_write_scaling_list(struct cedrus_ctx *ctx,
++					   struct cedrus_run *run)
++{
++	const struct v4l2_ctrl_hevc_scaling_matrix *scaling;
++	struct cedrus_dev *dev = ctx->dev;
++	u32 i, j, k, val;
++
++	scaling = run->h265.scaling_matrix;
++
++	cedrus_write(dev, VE_DEC_H265_SCALING_LIST_DC_COEF0,
++		     (scaling->scaling_list_dc_coef_32x32[1] << 24) |
++		     (scaling->scaling_list_dc_coef_32x32[0] << 16) |
++		     (scaling->scaling_list_dc_coef_16x16[1] << 8) |
++		     (scaling->scaling_list_dc_coef_16x16[0] << 0));
++
++	cedrus_write(dev, VE_DEC_H265_SCALING_LIST_DC_COEF1,
++		     (scaling->scaling_list_dc_coef_16x16[5] << 24) |
++		     (scaling->scaling_list_dc_coef_16x16[4] << 16) |
++		     (scaling->scaling_list_dc_coef_16x16[3] << 8) |
++		     (scaling->scaling_list_dc_coef_16x16[2] << 0));
++
++	cedrus_h265_sram_write_offset(dev, VE_DEC_H265_SRAM_OFFSET_SCALING_LISTS);
++
++	for (i = 0; i < 6; i++)
++		for (j = 0; j < 8; j++)
++			for (k = 0; k < 8; k += 4) {
++				val = ((u32)scaling->scaling_list_8x8[i][j + (k + 3) * 8] << 24) |
++				      ((u32)scaling->scaling_list_8x8[i][j + (k + 2) * 8] << 16) |
++				      ((u32)scaling->scaling_list_8x8[i][j + (k + 1) * 8] << 8) |
++				      scaling->scaling_list_8x8[i][j + k * 8];
++				cedrus_write(dev, VE_DEC_H265_SRAM_DATA, val);
++			}
++
++	for (i = 0; i < 2; i++)
++		for (j = 0; j < 8; j++)
++			for (k = 0; k < 8; k += 4) {
++				val = ((u32)scaling->scaling_list_32x32[i][j + (k + 3) * 8] << 24) |
++				      ((u32)scaling->scaling_list_32x32[i][j + (k + 2) * 8] << 16) |
++				      ((u32)scaling->scaling_list_32x32[i][j + (k + 1) * 8] << 8) |
++				      scaling->scaling_list_32x32[i][j + k * 8];
++				cedrus_write(dev, VE_DEC_H265_SRAM_DATA, val);
++			}
++
++	for (i = 0; i < 6; i++)
++		for (j = 0; j < 8; j++)
++			for (k = 0; k < 8; k += 4) {
++				val = ((u32)scaling->scaling_list_16x16[i][j + (k + 3) * 8] << 24) |
++				      ((u32)scaling->scaling_list_16x16[i][j + (k + 2) * 8] << 16) |
++				      ((u32)scaling->scaling_list_16x16[i][j + (k + 1) * 8] << 8) |
++				      scaling->scaling_list_16x16[i][j + k * 8];
++				cedrus_write(dev, VE_DEC_H265_SRAM_DATA, val);
++			}
++
++	for (i = 0; i < 6; i++)
++		for (j = 0; j < 4; j++) {
++			val = ((u32)scaling->scaling_list_4x4[i][j + 12] << 24) |
++			      ((u32)scaling->scaling_list_4x4[i][j + 8] << 16) |
++			      ((u32)scaling->scaling_list_4x4[i][j + 4] << 8) |
++			      scaling->scaling_list_4x4[i][j];
++			cedrus_write(dev, VE_DEC_H265_SRAM_DATA, val);
++		}
++}
++
++static void write_entry_point_list(struct cedrus_ctx *ctx,
++				   struct cedrus_run *run)
++{
++	const struct v4l2_ctrl_hevc_slice_params *slice_params;
++	unsigned int ctb_size_luma, width_in_ctb_luma;
++	unsigned int log2_max_luma_coding_block_size;
++	const struct v4l2_ctrl_hevc_pps *pps;
++	const struct v4l2_ctrl_hevc_sps *sps;
++	struct cedrus_dev *dev = ctx->dev;
++	uint32_t *entry_points;
++	int i, x, tx, y, ty;
++
++	pps = run->h265.pps;
++	sps = run->h265.sps;
++	slice_params = run->h265.slice_params;
++
++	log2_max_luma_coding_block_size =
++		sps->log2_min_luma_coding_block_size_minus3 + 3 +
++		sps->log2_diff_max_min_luma_coding_block_size;
++	ctb_size_luma = 1 << log2_max_luma_coding_block_size;
++	width_in_ctb_luma = DIV_ROUND_UP(sps->pic_width_in_luma_samples, ctb_size_luma);
++
++	for (x = 0, tx = 0; tx < pps->num_tile_columns_minus1 + 1; tx++) {
++		if (x + pps->column_width_minus1[tx] + 1 > (slice_params->slice_segment_addr % width_in_ctb_luma))
++			break;
++
++		x += pps->column_width_minus1[tx] + 1;
++	}
++
++	for (y = 0, ty = 0; ty < pps->num_tile_rows_minus1 + 1; ty++) {
++		if (y + pps->row_height_minus1[ty] + 1 > (slice_params->slice_segment_addr / width_in_ctb_luma))
++			break;
++
++		y += pps->row_height_minus1[ty] + 1;
++	}
++
++	cedrus_write(dev, VE_DEC_H265_TILE_START_CTB, (y << 16) | (x << 0));
++	cedrus_write(dev, VE_DEC_H265_TILE_END_CTB,
++		     ((y + pps->row_height_minus1[ty]) << 16) |
++		     ((x + pps->column_width_minus1[tx]) << 0));
++
++	entry_points = ctx->codec.h265.entry_points_buf;
++	if (pps->entropy_coding_sync_enabled_flag) {
++		for (i = 0; i < slice_params->num_entry_point_offsets; i++)
++			entry_points[i] = slice_params->entry_point_offset_minus1[i] + 1;
++	} else {
++		for (i = 0; i < slice_params->num_entry_point_offsets; i++) {
++			if (tx + 1 >= pps->num_tile_columns_minus1 + 1) {
++				x = tx = 0;
++				y += pps->row_height_minus1[ty++] + 1;
++			} else {
++				x += pps->column_width_minus1[tx++] + 1;
++			}
++
++			entry_points[i * 4 + 0] = slice_params->entry_point_offset_minus1[i] + 1;
++			entry_points[i * 4 + 1] = 0x0;
++			entry_points[i * 4 + 2] = (y << 16) | (x << 0);
++			entry_points[i * 4 + 3] = ((y + pps->row_height_minus1[ty]) << 16) | ((x + pps->column_width_minus1[tx]) << 0);
++		}
++	}
++}
++
+ static void cedrus_h265_setup(struct cedrus_ctx *ctx,
+ 			      struct cedrus_run *run)
+ {
+@@ -228,6 +349,7 @@ static void cedrus_h265_setup(struct cedrus_ctx *ctx,
+ 	const struct v4l2_ctrl_hevc_pps *pps;
+ 	const struct v4l2_ctrl_hevc_slice_params *slice_params;
+ 	const struct v4l2_hevc_pred_weight_table *pred_weight_table;
++	struct cedrus_buffer *cedrus_buf;
+ 	dma_addr_t src_buf_addr;
+ 	dma_addr_t src_buf_end_addr;
+ 	u32 chroma_log2_weight_denom;
+@@ -240,43 +362,10 @@ static void cedrus_h265_setup(struct cedrus_ctx *ctx,
+ 	slice_params = run->h265.slice_params;
+ 	pred_weight_table = &slice_params->pred_weight_table;
+ 
+-	/* MV column buffer size and allocation. */
+-	if (!ctx->codec.h265.mv_col_buf_size) {
+-		unsigned int num_buffers =
+-			run->dst->vb2_buf.vb2_queue->num_buffers;
+-		unsigned int log2_max_luma_coding_block_size =
+-			sps->log2_min_luma_coding_block_size_minus3 + 3 +
+-			sps->log2_diff_max_min_luma_coding_block_size;
+-		unsigned int ctb_size_luma =
+-			1 << log2_max_luma_coding_block_size;
+-
+-		/*
+-		 * Each CTB requires a MV col buffer with a specific unit size.
+-		 * Since the address is given with missing lsb bits, 1 KiB is
+-		 * added to each buffer to ensure proper alignment.
+-		 */
+-		ctx->codec.h265.mv_col_buf_unit_size =
+-			DIV_ROUND_UP(ctx->src_fmt.width, ctb_size_luma) *
+-			DIV_ROUND_UP(ctx->src_fmt.height, ctb_size_luma) *
+-			CEDRUS_H265_MV_COL_BUF_UNIT_CTB_SIZE + SZ_1K;
+-
+-		ctx->codec.h265.mv_col_buf_size = num_buffers *
+-			ctx->codec.h265.mv_col_buf_unit_size;
+-
+-		ctx->codec.h265.mv_col_buf =
+-			dma_alloc_coherent(dev->dev,
+-					   ctx->codec.h265.mv_col_buf_size,
+-					   &ctx->codec.h265.mv_col_buf_addr,
+-					   GFP_KERNEL);
+-		if (!ctx->codec.h265.mv_col_buf) {
+-			ctx->codec.h265.mv_col_buf_size = 0;
+-			// TODO: Abort the process here.
+-			return;
+-		}
+-	}
+-
+ 	/* Activate H265 engine. */
+ 	cedrus_engine_enable(dev, CEDRUS_CODEC_H265);
++	if (sps->pic_width_in_luma_samples > 2048)
++		cedrus_write(dev, VE_MODE, cedrus_read(dev, VE_MODE) | BIT(21));
+ 
+ 	/* Source offset and length in bits. */
+ 
+@@ -300,18 +389,35 @@ static void cedrus_h265_setup(struct cedrus_ctx *ctx,
+ 	src_buf_end_addr = src_buf_addr +
+ 			   DIV_ROUND_UP(slice_params->bit_size, 8);
+ 
+-	reg = VE_DEC_H265_BITS_END_ADDR_BASE(src_buf_end_addr);
++	reg = VE_DEC_H265_BITS_END_ADDR_BASE(ALIGN(src_buf_end_addr, 1024) - 1);
+ 	cedrus_write(dev, VE_DEC_H265_BITS_END_ADDR, reg);
+ 
+-	/* Coding tree block address: start at the beginning. */
+-	reg = VE_DEC_H265_DEC_CTB_ADDR_X(0) | VE_DEC_H265_DEC_CTB_ADDR_Y(0);
+-	cedrus_write(dev, VE_DEC_H265_DEC_CTB_ADDR, reg);
+-
+ 	cedrus_write(dev, VE_DEC_H265_TILE_START_CTB, 0);
+ 	cedrus_write(dev, VE_DEC_H265_TILE_END_CTB, 0);
+ 
++	if (pps->tiles_enabled_flag || pps->entropy_coding_sync_enabled_flag)
++		write_entry_point_list(ctx, run);
++
++	/* Coding tree block address */
++	reg = 0;
++	if (!slice_params->first_slice_segment_in_pic_flag) {
++		unsigned int ctb_size_luma, width_in_ctb_luma;
++		unsigned int log2_max_luma_coding_block_size;
++
++		log2_max_luma_coding_block_size =
++			sps->log2_min_luma_coding_block_size_minus3 + 3 +
++			sps->log2_diff_max_min_luma_coding_block_size;
++		ctb_size_luma = 1 << log2_max_luma_coding_block_size;
++		width_in_ctb_luma = DIV_ROUND_UP(sps->pic_width_in_luma_samples, ctb_size_luma);
++
++		reg = VE_DEC_H265_DEC_CTB_ADDR_X(slice_params->slice_segment_addr % width_in_ctb_luma);
++		reg |= VE_DEC_H265_DEC_CTB_ADDR_Y(slice_params->slice_segment_addr / width_in_ctb_luma);
++	}
++	cedrus_write(dev, VE_DEC_H265_DEC_CTB_ADDR, reg);
++
+ 	/* Clear the number of correctly-decoded coding tree blocks. */
+-	cedrus_write(dev, VE_DEC_H265_DEC_CTB_NUM, 0);
++	if (slice_params->first_slice_segment_in_pic_flag)
++		cedrus_write(dev, VE_DEC_H265_DEC_CTB_NUM, 0);
+ 
+ 	/* Initialize bitstream access. */
+ 	cedrus_write(dev, VE_DEC_H265_TRIGGER, VE_DEC_H265_TRIGGER_INIT_SWDEC);
+@@ -334,6 +440,7 @@ static void cedrus_h265_setup(struct cedrus_ctx *ctx,
+ 	      VE_DEC_H265_DEC_SPS_HDR_LOG2_DIFF_MAX_MIN_LUMA_CODING_BLOCK_SIZE(sps->log2_diff_max_min_luma_coding_block_size) |
+ 	      VE_DEC_H265_DEC_SPS_HDR_LOG2_MIN_LUMA_CODING_BLOCK_SIZE_MINUS3(sps->log2_min_luma_coding_block_size_minus3) |
+ 	      VE_DEC_H265_DEC_SPS_HDR_BIT_DEPTH_CHROMA_MINUS8(sps->bit_depth_chroma_minus8) |
++	      VE_DEC_H265_DEC_SPS_HDR_BIT_DEPTH_LUMA_MINUS8(sps->bit_depth_luma_minus8) |
+ 	      VE_DEC_H265_DEC_SPS_HDR_SEPARATE_COLOUR_PLANE_FLAG(sps->separate_colour_plane_flag) |
+ 	      VE_DEC_H265_DEC_SPS_HDR_CHROMA_FORMAT_IDC(sps->chroma_format_idc);
+ 
+@@ -363,7 +470,7 @@ static void cedrus_h265_setup(struct cedrus_ctx *ctx,
+ 	      VE_DEC_H265_DEC_PPS_CTRL1_PPS_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG(pps->pps_loop_filter_across_slices_enabled_flag) |
+ 	      VE_DEC_H265_DEC_PPS_CTRL1_LOOP_FILTER_ACROSS_TILES_ENABLED_FLAG(pps->loop_filter_across_tiles_enabled_flag) |
+ 	      VE_DEC_H265_DEC_PPS_CTRL1_ENTROPY_CODING_SYNC_ENABLED_FLAG(pps->entropy_coding_sync_enabled_flag) |
+-	      VE_DEC_H265_DEC_PPS_CTRL1_TILES_ENABLED_FLAG(0) |
++	      VE_DEC_H265_DEC_PPS_CTRL1_TILES_ENABLED_FLAG(pps->tiles_enabled_flag) |
+ 	      VE_DEC_H265_DEC_PPS_CTRL1_TRANSQUANT_BYPASS_ENABLE_FLAG(pps->transquant_bypass_enabled_flag) |
+ 	      VE_DEC_H265_DEC_PPS_CTRL1_WEIGHTED_BIPRED_FLAG(pps->weighted_bipred_flag) |
+ 	      VE_DEC_H265_DEC_PPS_CTRL1_WEIGHTED_PRED_FLAG(pps->weighted_pred_flag);
+@@ -384,7 +491,7 @@ static void cedrus_h265_setup(struct cedrus_ctx *ctx,
+ 	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_COLOUR_PLANE_ID(slice_params->colour_plane_id) |
+ 	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_SLICE_TYPE(slice_params->slice_type) |
+ 	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_DEPENDENT_SLICE_SEGMENT_FLAG(pps->dependent_slice_segment_flag) |
+-	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_FIRST_SLICE_SEGMENT_IN_PIC_FLAG(1);
++	      VE_DEC_H265_DEC_SLICE_HDR_INFO0_FIRST_SLICE_SEGMENT_IN_PIC_FLAG(slice_params->first_slice_segment_in_pic_flag);
+ 
+ 	cedrus_write(dev, VE_DEC_H265_DEC_SLICE_HDR_INFO0, reg);
+ 
+@@ -401,34 +508,68 @@ static void cedrus_h265_setup(struct cedrus_ctx *ctx,
+ 
+ 	chroma_log2_weight_denom = pred_weight_table->luma_log2_weight_denom +
+ 				   pred_weight_table->delta_chroma_log2_weight_denom;
+-	reg = VE_DEC_H265_DEC_SLICE_HDR_INFO2_NUM_ENTRY_POINT_OFFSETS(0) |
++	reg = VE_DEC_H265_DEC_SLICE_HDR_INFO2_NUM_ENTRY_POINT_OFFSETS(slice_params->num_entry_point_offsets) |
+ 	      VE_DEC_H265_DEC_SLICE_HDR_INFO2_CHROMA_LOG2_WEIGHT_DENOM(chroma_log2_weight_denom) |
+ 	      VE_DEC_H265_DEC_SLICE_HDR_INFO2_LUMA_LOG2_WEIGHT_DENOM(pred_weight_table->luma_log2_weight_denom);
+ 
+ 	cedrus_write(dev, VE_DEC_H265_DEC_SLICE_HDR_INFO2, reg);
+ 
++	cedrus_write(dev, VE_DEC_H265_ENTRY_POINT_OFFSET_ADDR, ctx->codec.h265.entry_points_buf_addr >> 8);
++
+ 	/* Decoded picture size. */
+ 
+-	reg = VE_DEC_H265_DEC_PIC_SIZE_WIDTH(ctx->src_fmt.width) |
+-	      VE_DEC_H265_DEC_PIC_SIZE_HEIGHT(ctx->src_fmt.height);
++	reg = VE_DEC_H265_DEC_PIC_SIZE_WIDTH(sps->pic_width_in_luma_samples) |
++	      VE_DEC_H265_DEC_PIC_SIZE_HEIGHT(sps->pic_height_in_luma_samples);
+ 
+ 	cedrus_write(dev, VE_DEC_H265_DEC_PIC_SIZE, reg);
+ 
+-	/* Scaling list. */
++	/* Scaling list */
+ 
+-	reg = VE_DEC_H265_SCALING_LIST_CTRL0_DEFAULT;
++	if (sps->scaling_list_enabled_flag) {
++		cedrus_h265_write_scaling_list(ctx, run);
++		reg = VE_DEC_H265_SCALING_LIST_CTRL0_ENABLED_FLAG(1);
++	} else {
++		reg = VE_DEC_H265_SCALING_LIST_CTRL0_DEFAULT;
++	}
+ 	cedrus_write(dev, VE_DEC_H265_SCALING_LIST_CTRL0, reg);
+ 
+ 	/* Neightbor information address. */
+ 	reg = VE_DEC_H265_NEIGHBOR_INFO_ADDR_BASE(ctx->codec.h265.neighbor_info_buf_addr);
+ 	cedrus_write(dev, VE_DEC_H265_NEIGHBOR_INFO_ADDR, reg);
+ 
++	cedrus_write(dev, VE_DEC_H265_LOW_ADDR, 0);
++
+ 	/* Write decoded picture buffer in pic list. */
+ 	cedrus_h265_frame_info_write_dpb(ctx, slice_params->dpb,
+ 					 slice_params->num_active_dpb_entries);
+ 
+ 	/* Output frame. */
+ 
++	cedrus_buf = vb2_to_cedrus_buffer(ctx->dst_bufs[run->dst->vb2_buf.index]);
++	if (!cedrus_buf->mv_col_buf_size) {
++		unsigned int ctb_size_luma, width_in_ctb_luma;
++		unsigned int log2_max_luma_coding_block_size;
++
++		log2_max_luma_coding_block_size =
++			sps->log2_min_luma_coding_block_size_minus3 + 3 +
++			sps->log2_diff_max_min_luma_coding_block_size;
++		ctb_size_luma = 1 << log2_max_luma_coding_block_size;
++		width_in_ctb_luma = DIV_ROUND_UP(sps->pic_width_in_luma_samples, ctb_size_luma);
++
++		cedrus_buf->mv_col_buf_size = ALIGN(width_in_ctb_luma *
++		DIV_ROUND_UP(sps->pic_height_in_luma_samples, ctb_size_luma) *
++		CEDRUS_H265_MV_COL_BUF_UNIT_CTB_SIZE, 1024);
++
++		cedrus_buf->mv_col_buf =
++			dma_alloc_coherent(dev->dev,
++					   cedrus_buf->mv_col_buf_size,
++					   &cedrus_buf->mv_col_buf_dma,
++					   GFP_KERNEL);
++
++		if (!cedrus_buf->mv_col_buf)
++			cedrus_buf->mv_col_buf_size = 0;
++	}
++
+ 	output_pic_list_index = V4L2_HEVC_DPB_ENTRIES_NUM_MAX;
+ 	pic_order_cnt[0] = slice_params->slice_pic_order_cnt;
+ 	pic_order_cnt[1] = slice_params->slice_pic_order_cnt;
+@@ -444,36 +585,36 @@ static void cedrus_h265_setup(struct cedrus_ctx *ctx,
+ 	if (slice_params->slice_type != V4L2_HEVC_SLICE_TYPE_I) {
+ 		cedrus_h265_ref_pic_list_write(dev, slice_params->dpb,
+ 					       slice_params->ref_idx_l0,
+-					       slice_params->num_ref_idx_l0_active_minus1 + 1,
+-					       VE_DEC_H265_SRAM_OFFSET_REF_PIC_LIST0);
++			slice_params->num_ref_idx_l0_active_minus1 + 1,
++			VE_DEC_H265_SRAM_OFFSET_REF_PIC_LIST0);
+ 
+ 		if (pps->weighted_pred_flag || pps->weighted_bipred_flag)
+ 			cedrus_h265_pred_weight_write(dev,
+-						      pred_weight_table->delta_luma_weight_l0,
+-						      pred_weight_table->luma_offset_l0,
+-						      pred_weight_table->delta_chroma_weight_l0,
+-						      pred_weight_table->chroma_offset_l0,
+-						      slice_params->num_ref_idx_l0_active_minus1 + 1,
+-						      VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_LUMA_L0,
+-						      VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_CHROMA_L0);
++				pred_weight_table->delta_luma_weight_l0,
++				pred_weight_table->luma_offset_l0,
++				pred_weight_table->delta_chroma_weight_l0,
++				pred_weight_table->chroma_offset_l0,
++				slice_params->num_ref_idx_l0_active_minus1 + 1,
++				VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_LUMA_L0,
++				VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_CHROMA_L0);
+ 	}
+ 
+ 	/* Reference picture list 1 (for B frames). */
+ 	if (slice_params->slice_type == V4L2_HEVC_SLICE_TYPE_B) {
+ 		cedrus_h265_ref_pic_list_write(dev, slice_params->dpb,
+ 					       slice_params->ref_idx_l1,
+-					       slice_params->num_ref_idx_l1_active_minus1 + 1,
+-					       VE_DEC_H265_SRAM_OFFSET_REF_PIC_LIST1);
++			slice_params->num_ref_idx_l1_active_minus1 + 1,
++			VE_DEC_H265_SRAM_OFFSET_REF_PIC_LIST1);
+ 
+ 		if (pps->weighted_bipred_flag)
+ 			cedrus_h265_pred_weight_write(dev,
+-						      pred_weight_table->delta_luma_weight_l1,
+-						      pred_weight_table->luma_offset_l1,
+-						      pred_weight_table->delta_chroma_weight_l1,
+-						      pred_weight_table->chroma_offset_l1,
+-						      slice_params->num_ref_idx_l1_active_minus1 + 1,
+-						      VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_LUMA_L1,
+-						      VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_CHROMA_L1);
++				pred_weight_table->delta_luma_weight_l1,
++				pred_weight_table->luma_offset_l1,
++				pred_weight_table->delta_chroma_weight_l1,
++				pred_weight_table->chroma_offset_l1,
++				slice_params->num_ref_idx_l1_active_minus1 + 1,
++				VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_LUMA_L1,
++				VE_DEC_H265_SRAM_OFFSET_PRED_WEIGHT_CHROMA_L1);
+ 	}
+ 
+ 	/* Enable appropriate interruptions. */
+@@ -484,9 +625,6 @@ static int cedrus_h265_start(struct cedrus_ctx *ctx)
+ {
+ 	struct cedrus_dev *dev = ctx->dev;
+ 
+-	/* The buffer size is calculated at setup time. */
+-	ctx->codec.h265.mv_col_buf_size = 0;
+-
+ 	ctx->codec.h265.neighbor_info_buf =
+ 		dma_alloc_coherent(dev->dev, CEDRUS_H265_NEIGHBOR_INFO_BUF_SIZE,
+ 				   &ctx->codec.h265.neighbor_info_buf_addr,
+@@ -494,6 +632,17 @@ static int cedrus_h265_start(struct cedrus_ctx *ctx)
+ 	if (!ctx->codec.h265.neighbor_info_buf)
+ 		return -ENOMEM;
+ 
++	ctx->codec.h265.entry_points_buf =
++		dma_alloc_coherent(dev->dev, CEDRUS_H265_ENTRY_POINTS_BUF_SIZE,
++				   &ctx->codec.h265.entry_points_buf_addr,
++				   GFP_KERNEL);
++	if (!ctx->codec.h265.entry_points_buf) {
++		dma_free_coherent(dev->dev, CEDRUS_H265_NEIGHBOR_INFO_BUF_SIZE,
++				  ctx->codec.h265.neighbor_info_buf,
++				  ctx->codec.h265.neighbor_info_buf_addr);
++		return -ENOMEM;
++	}
++
+ 	return 0;
+ }
+ 
+@@ -501,17 +650,12 @@ static void cedrus_h265_stop(struct cedrus_ctx *ctx)
+ {
+ 	struct cedrus_dev *dev = ctx->dev;
+ 
+-	if (ctx->codec.h265.mv_col_buf_size > 0) {
+-		dma_free_coherent(dev->dev, ctx->codec.h265.mv_col_buf_size,
+-				  ctx->codec.h265.mv_col_buf,
+-				  ctx->codec.h265.mv_col_buf_addr);
+-
+-		ctx->codec.h265.mv_col_buf_size = 0;
+-	}
+-
+ 	dma_free_coherent(dev->dev, CEDRUS_H265_NEIGHBOR_INFO_BUF_SIZE,
+ 			  ctx->codec.h265.neighbor_info_buf,
+ 			  ctx->codec.h265.neighbor_info_buf_addr);
++	dma_free_coherent(dev->dev, CEDRUS_H265_ENTRY_POINTS_BUF_SIZE,
++			  ctx->codec.h265.entry_points_buf,
++			  ctx->codec.h265.entry_points_buf_addr);
+ }
+ 
+ static void cedrus_h265_trigger(struct cedrus_ctx *ctx)
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_regs.h b/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
+index 87651d6b6..8d153dbe4 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
+@@ -496,6 +496,9 @@
+ #define VE_DEC_H265_TILE_START_CTB		(VE_ENGINE_DEC_H265 + 0x68)
+ #define VE_DEC_H265_TILE_END_CTB		(VE_ENGINE_DEC_H265 + 0x6c)
+ 
++#define VE_DEC_H265_SCALING_LIST_DC_COEF0	(VE_ENGINE_DEC_H265 + 0x78)
++#define VE_DEC_H265_SCALING_LIST_DC_COEF1	(VE_ENGINE_DEC_H265 + 0x7c)
++
+ #define VE_DEC_H265_LOW_ADDR			(VE_ENGINE_DEC_H265 + 0x80)
+ 
+ #define VE_DEC_H265_LOW_ADDR_PRIMARY_CHROMA(a) \
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_video.c b/drivers/staging/media/sunxi/cedrus/cedrus_video.c
+index 6cc65d85c..4d4114069 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_video.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_video.c
+@@ -433,8 +433,18 @@ static void cedrus_buf_cleanup(struct vb2_buffer *vb)
+ 	struct vb2_queue *vq = vb->vb2_queue;
+ 	struct cedrus_ctx *ctx = vb2_get_drv_priv(vq);
+ 
+-	if (!V4L2_TYPE_IS_OUTPUT(vq->type))
++	if (!V4L2_TYPE_IS_OUTPUT(vq->type)) {
++		struct cedrus_buffer *cedrus_buf;
++
++		cedrus_buf = vb2_to_cedrus_buffer(ctx->dst_bufs[vb->index]);
++
++		if (cedrus_buf->mv_col_buf_size)
++			dma_free_coherent(ctx->dev->dev,
++					  cedrus_buf->mv_col_buf_size,
++					  cedrus_buf->mv_col_buf,
++					  cedrus_buf->mv_col_buf_dma);
+ 		ctx->dst_bufs[vb->index] = NULL;
++	}
+ }
+ 
+ static int cedrus_buf_out_validate(struct vb2_buffer *vb)
+diff --git a/include/media/hevc-ctrls.h b/include/media/hevc-ctrls.h
+index 2de83d9f6..19469097c 100644
+--- a/include/media/hevc-ctrls.h
++++ b/include/media/hevc-ctrls.h
+@@ -17,11 +17,13 @@
+ #define V4L2_CID_MPEG_VIDEO_HEVC_SPS		(V4L2_CID_MPEG_BASE + 1008)
+ #define V4L2_CID_MPEG_VIDEO_HEVC_PPS		(V4L2_CID_MPEG_BASE + 1009)
+ #define V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS	(V4L2_CID_MPEG_BASE + 1010)
++#define V4L2_CID_MPEG_VIDEO_HEVC_SCALING_MATRIX	(V4L2_CID_MPEG_BASE + 1011)
+ 
+ /* enum v4l2_ctrl_type type values */
+ #define V4L2_CTRL_TYPE_HEVC_SPS 0x0120
+ #define V4L2_CTRL_TYPE_HEVC_PPS 0x0121
+ #define V4L2_CTRL_TYPE_HEVC_SLICE_PARAMS 0x0122
++#define V4L2_CTRL_TYPE_HEVC_SCALING_MATRIX 0x0123
+ 
+ #define V4L2_HEVC_SLICE_TYPE_B	0
+ #define V4L2_HEVC_SLICE_TYPE_P	1
+@@ -95,7 +97,7 @@ struct v4l2_ctrl_hevc_pps {
+ 	__u8	lists_modification_present_flag;
+ 	__u8	log2_parallel_merge_level_minus2;
+ 	__u8	slice_segment_header_extension_present_flag;
+-	__u8	padding;
++	__u8	scaling_list_enable_flag;
+ };
+ 
+ #define V4L2_HEVC_DPB_ENTRY_RPS_ST_CURR_BEFORE	0x01
+@@ -179,7 +181,21 @@ struct v4l2_ctrl_hevc_slice_params {
+ 	/* ISO/IEC 23008-2, ITU-T Rec. H.265: Weighted prediction parameter */
+ 	struct v4l2_hevc_pred_weight_table pred_weight_table;
+ 
+-	__u8	padding[2];
++	__u32	slice_segment_addr;
++	__u32	num_entry_point_offsets;
++	__u32	entry_point_offset_minus1[256];
++	__u8	first_slice_segment_in_pic_flag;
++
++	__u8	padding;
++};
++
++struct v4l2_ctrl_hevc_scaling_matrix {
++	__u8	scaling_list_4x4[6][16];
++	__u8	scaling_list_8x8[6][64];
++	__u8	scaling_list_16x16[6][64];
++	__u8	scaling_list_32x32[2][64];
++	__u8	scaling_list_dc_coef_16x16[6];
++	__u8	scaling_list_dc_coef_32x32[2];
+ };
+ 
+ #endif
+-- 
+2.17.1
+

--- a/patch/kernel/sunxi-next-olinuxino/0157-cedrus-h264-4k.patch
+++ b/patch/kernel/sunxi-next-olinuxino/0157-cedrus-h264-4k.patch
@@ -1,0 +1,362 @@
+From c23076f636eea68c5f71753f504dccd10098633d Mon Sep 17 00:00:00 2001
+From: hehopmajieh <hehopmajieh@debian.bg>
+Date: Fri, 3 Jan 2020 23:34:19 +0200
+Subject: [PATCH 7/7] cedrus h264 4k From
+ 6a900f36a70f921886f05373846368ca6f09446e Mon Sep 17 00:00:00 2001 From:
+ Jernej Skrabec <jernej.skrabec@siol.net> Date: Sat, 25 May 2019 14:16:55
+ +0200 Subject: [PATCH 5/5] cedrus h264 4k
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ drivers/staging/media/sunxi/cedrus/cedrus.h   |  12 +-
+ .../staging/media/sunxi/cedrus/cedrus_h264.c  | 117 +++++++++++-------
+ .../staging/media/sunxi/cedrus/cedrus_h265.c  |   4 +-
+ .../staging/media/sunxi/cedrus/cedrus_hw.c    |  11 +-
+ .../staging/media/sunxi/cedrus/cedrus_hw.h    |   3 +-
+ .../staging/media/sunxi/cedrus/cedrus_mpeg2.c |   2 +-
+ .../staging/media/sunxi/cedrus/cedrus_regs.h  |   4 +
+ .../staging/media/sunxi/cedrus/cedrus_video.c |   4 +-
+ 8 files changed, 98 insertions(+), 59 deletions(-)
+
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus.h b/drivers/staging/media/sunxi/cedrus/cedrus.h
+index b518c5613..ee00449d3 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus.h
++++ b/drivers/staging/media/sunxi/cedrus/cedrus.h
+@@ -118,14 +118,18 @@ struct cedrus_ctx {
+ 
+ 	union {
+ 		struct {
+-			void		*mv_col_buf;
+-			dma_addr_t	mv_col_buf_dma;
+-			ssize_t		mv_col_buf_field_size;
+-			ssize_t		mv_col_buf_size;
+ 			void		*pic_info_buf;
+ 			dma_addr_t	pic_info_buf_dma;
+ 			void		*neighbor_info_buf;
+ 			dma_addr_t	neighbor_info_buf_dma;
++
++			void		*deblk_buf;
++			dma_addr_t	deblk_buf_dma;
++			ssize_t		deblk_buf_size;
++
++			void		*intra_pred_buf;
++			dma_addr_t	intra_pred_buf_dma;
++			ssize_t		intra_pred_buf_size;
+ 		} h264;
+ 		struct {
+ 			void		*neighbor_info_buf;
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+index dcb8d3837..4fafaf2c6 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_h264.c
+@@ -55,16 +55,14 @@ static void cedrus_h264_write_sram(struct cedrus_dev *dev,
+ }
+ 
+ static dma_addr_t cedrus_h264_mv_col_buf_addr(struct cedrus_ctx *ctx,
+-					      unsigned int position,
++					      struct cedrus_buffer *buf,
+ 					      unsigned int field)
+ {
+-	dma_addr_t addr = ctx->codec.h264.mv_col_buf_dma;
+-
+-	/* Adjust for the position */
+-	addr += position * ctx->codec.h264.mv_col_buf_field_size * 2;
++	dma_addr_t addr = buf->mv_col_buf_dma;
+ 
+ 	/* Adjust for the field */
+-	addr += field * ctx->codec.h264.mv_col_buf_field_size;
++	if (field)
++		addr += buf->mv_col_buf_size / 2;
+ 
+ 	return addr;
+ }
+@@ -76,7 +74,6 @@ static void cedrus_fill_ref_pic(struct cedrus_ctx *ctx,
+ 				struct cedrus_h264_sram_ref_pic *pic)
+ {
+ 	struct vb2_buffer *vbuf = &buf->m2m_buf.vb.vb2_buf;
+-	unsigned int position = buf->codec.h264.position;
+ 
+ 	pic->top_field_order_cnt = cpu_to_le32(top_field_order_cnt);
+ 	pic->bottom_field_order_cnt = cpu_to_le32(bottom_field_order_cnt);
+@@ -85,9 +82,9 @@ static void cedrus_fill_ref_pic(struct cedrus_ctx *ctx,
+ 	pic->luma_ptr = cpu_to_le32(cedrus_buf_addr(vbuf, &ctx->dst_fmt, 0));
+ 	pic->chroma_ptr = cpu_to_le32(cedrus_buf_addr(vbuf, &ctx->dst_fmt, 1));
+ 	pic->mv_col_top_ptr =
+-		cpu_to_le32(cedrus_h264_mv_col_buf_addr(ctx, position, 0));
++		cpu_to_le32(cedrus_h264_mv_col_buf_addr(ctx, buf, 0));
+ 	pic->mv_col_bot_ptr =
+-		cpu_to_le32(cedrus_h264_mv_col_buf_addr(ctx, position, 1));
++		cpu_to_le32(cedrus_h264_mv_col_buf_addr(ctx, buf, 1));
+ }
+ 
+ static void cedrus_write_frame_list(struct cedrus_ctx *ctx,
+@@ -145,6 +142,28 @@ static void cedrus_write_frame_list(struct cedrus_ctx *ctx,
+ 	output_buf = vb2_to_cedrus_buffer(&run->dst->vb2_buf);
+ 	output_buf->codec.h264.position = position;
+ 
++	if (!output_buf->mv_col_buf_size) {
++		const struct v4l2_ctrl_h264_sps *sps = run->h264.sps;
++		unsigned int field_size;
++
++		field_size = DIV_ROUND_UP(ctx->src_fmt.width, 16) *
++			DIV_ROUND_UP(ctx->src_fmt.height, 16) * 16;
++		if (!(sps->flags & V4L2_H264_SPS_FLAG_DIRECT_8X8_INFERENCE))
++			field_size = field_size * 2;
++		if (!(sps->flags & V4L2_H264_SPS_FLAG_FRAME_MBS_ONLY))
++			field_size = field_size * 2;
++
++		output_buf->mv_col_buf_size = field_size * 2;
++		output_buf->mv_col_buf =
++			dma_alloc_coherent(dev->dev,
++					   output_buf->mv_col_buf_size,
++					   &output_buf->mv_col_buf_dma,
++					   GFP_KERNEL);
++
++		if (!output_buf->mv_col_buf)
++			output_buf->mv_col_buf_size = 0;
++	}
++
+ 	if (slice->flags & V4L2_H264_SLICE_FLAG_FIELD_PIC)
+ 		output_buf->codec.h264.pic_type = CEDRUS_H264_PIC_TYPE_FIELD;
+ 	else if (sps->flags & V4L2_H264_SPS_FLAG_MB_ADAPTIVE_FRAME_FIELD)
+@@ -338,6 +357,14 @@ static void cedrus_set_params(struct cedrus_ctx *ctx,
+ 		     VE_H264_VLD_ADDR_FIRST | VE_H264_VLD_ADDR_VALID |
+ 		     VE_H264_VLD_ADDR_LAST);
+ 
++	if (((sps->pic_width_in_mbs_minus1 + 1) * 16) > 2048) {
++		cedrus_write(dev, VE_DBLK_INTRAPRED_BUF_CTRL, 0x5);
++		cedrus_write(dev, VE_DBLK_DRAM_BUF_ADDR,
++			     ctx->codec.h264.deblk_buf_dma);
++		cedrus_write(dev, VE_INTRAPRED_DRAM_BUF_ADDR,
++			     ctx->codec.h264.intra_pred_buf_dma);
++	}
++
+ 	/*
+ 	 * FIXME: Since the bitstream parsing is done in software, and
+ 	 * in userspace, this shouldn't be needed anymore. But it
+@@ -476,7 +503,8 @@ static void cedrus_h264_setup(struct cedrus_ctx *ctx,
+ {
+ 	struct cedrus_dev *dev = ctx->dev;
+ 
+-	cedrus_engine_enable(dev, CEDRUS_CODEC_H264);
++	cedrus_engine_enable(dev, CEDRUS_CODEC_H264,
++			     ctx->src_fmt.width);
+ 
+ 	cedrus_write(dev, VE_H264_SDROT_CTRL, 0);
+ 	cedrus_write(dev, VE_H264_EXTRA_BUFFER1,
+@@ -493,8 +521,6 @@ static void cedrus_h264_setup(struct cedrus_ctx *ctx,
+ static int cedrus_h264_start(struct cedrus_ctx *ctx)
+ {
+ 	struct cedrus_dev *dev = ctx->dev;
+-	unsigned int field_size;
+-	unsigned int mv_col_size;
+ 	int ret;
+ 
+ 	/*
+@@ -526,44 +552,42 @@ static int cedrus_h264_start(struct cedrus_ctx *ctx)
+ 		goto err_pic_buf;
+ 	}
+ 
+-	field_size = DIV_ROUND_UP(ctx->src_fmt.width, 16) *
+-		DIV_ROUND_UP(ctx->src_fmt.height, 16) * 16;
+-
+-	/*
+-	 * FIXME: This is actually conditional to
+-	 * V4L2_H264_SPS_FLAG_DIRECT_8X8_INFERENCE not being set, we
+-	 * might have to rework this if memory efficiency ever is
+-	 * something we need to work on.
+-	 */
+-	field_size = field_size * 2;
++	if (ctx->src_fmt.width > 2048) {
++		ctx->codec.h264.deblk_buf_size =
++			ALIGN(ctx->src_fmt.width, 32) * 12;
++		ctx->codec.h264.deblk_buf =
++			dma_alloc_coherent(dev->dev,
++					   ctx->codec.h264.deblk_buf_size,
++					   &ctx->codec.h264.deblk_buf_dma,
++					   GFP_KERNEL);
++		if (!ctx->codec.h264.deblk_buf) {
++			ret = -ENOMEM;
++			goto err_neighbor_buf;
++		}
+ 
+-	/*
+-	 * FIXME: This is actually conditional to
+-	 * V4L2_H264_SPS_FLAG_FRAME_MBS_ONLY not being set, we might
+-	 * have to rework this if memory efficiency ever is something
+-	 * we need to work on.
+-	 */
+-	field_size = field_size * 2;
+-	ctx->codec.h264.mv_col_buf_field_size = field_size;
+-
+-	mv_col_size = field_size * 2 * CEDRUS_H264_FRAME_NUM;
+-	ctx->codec.h264.mv_col_buf_size = mv_col_size;
+-	ctx->codec.h264.mv_col_buf = dma_alloc_coherent(dev->dev,
+-							ctx->codec.h264.mv_col_buf_size,
+-							&ctx->codec.h264.mv_col_buf_dma,
+-							GFP_KERNEL);
+-	if (!ctx->codec.h264.mv_col_buf) {
+-		ret = -ENOMEM;
+-		goto err_neighbor_buf;
++		ctx->codec.h264.intra_pred_buf_size =
++			ALIGN(ctx->src_fmt.width, 64) * 5;
++		ctx->codec.h264.intra_pred_buf =
++			dma_alloc_coherent(dev->dev,
++					   ctx->codec.h264.intra_pred_buf_size,
++					   &ctx->codec.h264.intra_pred_buf_dma,
++					   GFP_KERNEL);
++		if (!ctx->codec.h264.intra_pred_buf) {
++			ret = -ENOMEM;
++			goto err_deblk_buf;
++		}
+ 	}
+ 
+ 	return 0;
+ 
++err_deblk_buf:
++	dma_free_coherent(dev->dev, ctx->codec.h264.deblk_buf_size,
++			  ctx->codec.h264.deblk_buf,
++			  ctx->codec.h264.deblk_buf_dma);
+ err_neighbor_buf:
+ 	dma_free_coherent(dev->dev, CEDRUS_NEIGHBOR_INFO_BUF_SIZE,
+ 			  ctx->codec.h264.neighbor_info_buf,
+ 			  ctx->codec.h264.neighbor_info_buf_dma);
+-
+ err_pic_buf:
+ 	dma_free_coherent(dev->dev, CEDRUS_PIC_INFO_BUF_SIZE,
+ 			  ctx->codec.h264.pic_info_buf,
+@@ -575,15 +599,20 @@ static void cedrus_h264_stop(struct cedrus_ctx *ctx)
+ {
+ 	struct cedrus_dev *dev = ctx->dev;
+ 
+-	dma_free_coherent(dev->dev, ctx->codec.h264.mv_col_buf_size,
+-			  ctx->codec.h264.mv_col_buf,
+-			  ctx->codec.h264.mv_col_buf_dma);
+ 	dma_free_coherent(dev->dev, CEDRUS_NEIGHBOR_INFO_BUF_SIZE,
+ 			  ctx->codec.h264.neighbor_info_buf,
+ 			  ctx->codec.h264.neighbor_info_buf_dma);
+ 	dma_free_coherent(dev->dev, CEDRUS_PIC_INFO_BUF_SIZE,
+ 			  ctx->codec.h264.pic_info_buf,
+ 			  ctx->codec.h264.pic_info_buf_dma);
++	if (ctx->codec.h264.deblk_buf_size)
++		dma_free_coherent(dev->dev, ctx->codec.h264.deblk_buf_size,
++				  ctx->codec.h264.deblk_buf,
++				  ctx->codec.h264.deblk_buf_dma);
++	if (ctx->codec.h264.intra_pred_buf_size)
++		dma_free_coherent(dev->dev, ctx->codec.h264.intra_pred_buf_size,
++				  ctx->codec.h264.intra_pred_buf,
++				  ctx->codec.h264.intra_pred_buf_dma);
+ }
+ 
+ static void cedrus_h264_trigger(struct cedrus_ctx *ctx)
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_h265.c b/drivers/staging/media/sunxi/cedrus/cedrus_h265.c
+index 82d29c59b..8bbbe69ae 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_h265.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_h265.c
+@@ -363,9 +363,7 @@ static void cedrus_h265_setup(struct cedrus_ctx *ctx,
+ 	pred_weight_table = &slice_params->pred_weight_table;
+ 
+ 	/* Activate H265 engine. */
+-	cedrus_engine_enable(dev, CEDRUS_CODEC_H265);
+-	if (sps->pic_width_in_luma_samples > 2048)
+-		cedrus_write(dev, VE_MODE, cedrus_read(dev, VE_MODE) | BIT(21));
++	cedrus_engine_enable(dev, CEDRUS_CODEC_H265, ctx->src_fmt.width);
+ 
+ 	/* Source offset and length in bits. */
+ 
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_hw.c b/drivers/staging/media/sunxi/cedrus/cedrus_hw.c
+index 7d2f6eedf..9503d3958 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_hw.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_hw.c
+@@ -30,7 +30,8 @@
+ #include "cedrus_hw.h"
+ #include "cedrus_regs.h"
+ 
+-int cedrus_engine_enable(struct cedrus_dev *dev, enum cedrus_codec codec)
++int cedrus_engine_enable(struct cedrus_dev *dev, enum cedrus_codec codec,
++			 unsigned int width)
+ {
+ 	u32 reg = 0;
+ 
+@@ -58,6 +59,11 @@ int cedrus_engine_enable(struct cedrus_dev *dev, enum cedrus_codec codec)
+ 		return -EINVAL;
+ 	}
+ 
++	if (width >= 4096)
++		reg |= BIT(22);
++	if (width > 2048)
++		reg |= BIT(21);
++
+ 	cedrus_write(dev, VE_MODE, reg);
+ 
+ 	return 0;
+@@ -83,9 +89,6 @@ void cedrus_dst_format_set(struct cedrus_dev *dev,
+ 		reg = VE_PRIMARY_OUT_FMT_NV12;
+ 		cedrus_write(dev, VE_PRIMARY_OUT_FMT, reg);
+ 
+-		reg = VE_CHROMA_BUF_LEN_SDRT(chroma_size / 2);
+-		cedrus_write(dev, VE_CHROMA_BUF_LEN, reg);
+-
+ 		reg = chroma_size / 2;
+ 		cedrus_write(dev, VE_PRIMARY_CHROMA_BUF_LEN, reg);
+ 
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_hw.h b/drivers/staging/media/sunxi/cedrus/cedrus_hw.h
+index 27d088239..0e67c6981 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_hw.h
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_hw.h
+@@ -16,7 +16,8 @@
+ #ifndef _CEDRUS_HW_H_
+ #define _CEDRUS_HW_H_
+ 
+-int cedrus_engine_enable(struct cedrus_dev *dev, enum cedrus_codec codec);
++int cedrus_engine_enable(struct cedrus_dev *dev, enum cedrus_codec codec,
++			 unsigned int width);
+ void cedrus_engine_disable(struct cedrus_dev *dev);
+ 
+ void cedrus_dst_format_set(struct cedrus_dev *dev,
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_mpeg2.c b/drivers/staging/media/sunxi/cedrus/cedrus_mpeg2.c
+index 13c34927b..fc00a2cbf 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_mpeg2.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_mpeg2.c
+@@ -96,7 +96,7 @@ static void cedrus_mpeg2_setup(struct cedrus_ctx *ctx, struct cedrus_run *run)
+ 	quantization = run->mpeg2.quantization;
+ 
+ 	/* Activate MPEG engine. */
+-	cedrus_engine_enable(dev, CEDRUS_CODEC_MPEG2);
++	cedrus_engine_enable(dev, CEDRUS_CODEC_MPEG2, ctx->src_fmt.width);
+ 
+ 	/* Set intra quantization matrix. */
+ 
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_regs.h b/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
+index 8d153dbe4..d1f010ae4 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_regs.h
+@@ -41,6 +41,10 @@
+ #define VE_MODE_DEC_H264			(0x01 << 0)
+ #define VE_MODE_DEC_MPEG			(0x00 << 0)
+ 
++#define VE_DBLK_INTRAPRED_BUF_CTRL		0x50
++#define VE_DBLK_DRAM_BUF_ADDR			0x54
++#define VE_INTRAPRED_DRAM_BUF_ADDR		0x58
++
+ #define VE_PRIMARY_CHROMA_BUF_LEN		0xc4
+ #define VE_PRIMARY_FB_LINE_STRIDE		0xc8
+ 
+diff --git a/drivers/staging/media/sunxi/cedrus/cedrus_video.c b/drivers/staging/media/sunxi/cedrus/cedrus_video.c
+index 4d4114069..d07321e03 100644
+--- a/drivers/staging/media/sunxi/cedrus/cedrus_video.c
++++ b/drivers/staging/media/sunxi/cedrus/cedrus_video.c
+@@ -29,8 +29,8 @@
+ 
+ #define CEDRUS_MIN_WIDTH	16U
+ #define CEDRUS_MIN_HEIGHT	16U
+-#define CEDRUS_MAX_WIDTH	3840U
+-#define CEDRUS_MAX_HEIGHT	2160U
++#define CEDRUS_MAX_WIDTH	4096U
++#define CEDRUS_MAX_HEIGHT	2768U
+ 
+ static struct cedrus_format cedrus_formats[] = {
+ 	{
+-- 
+2.17.1
+


### PR DESCRIPTION
- Backport V4L API from 5.3
- Additional patches to cedrus
- Cedar is anbled in kernel config by default

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - pull request is opened to the `master` branch unless you are working on a specfic feature which is developed in a separate branch
 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
