### PR TITLE
Add wifi-8723bs-AP-bugfix.patch to sunxi-next-olinuxino

### DIFF
--- a/patch/kernel/sunxi-next-olinuxino/wifi-8723bs-AP-bugfix.patch
+++ b/patch/kernel/sunxi-next-olinuxino/wifi-8723bs-AP-bugfix.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/staging/rtl8723bs/os_dep/ioctl_cfg80211.c b/drivers/staging/rtl8723bs/os_dep/ioctl_cfg80211.c
+index db553f2e4..56bfdc9e5 100644
+--- a/drivers/staging/rtl8723bs/os_dep/ioctl_cfg80211.c
++++ b/drivers/staging/rtl8723bs/os_dep/ioctl_cfg80211.c
+@@ -2424,6 +2424,7 @@ void rtw_cfg80211_indicate_sta_assoc(struct adapter *padapter, u8 *pmgmt_frame,
+ 			ie_offset = _REASOCREQ_IE_OFFSET_;
+ 
+ 		sinfo.filled = 0;
++		sinfo.pertid = 0;
+ 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
+ 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;
+ 		cfg80211_new_sta(ndev, GetAddr2Ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);


### PR DESCRIPTION
On A64, this avoids a kernel oops when the WiFi interface is in AP mode.  I've already sent this by e-mail, and even got an acknowledgment, but it appears to have been ignored.